### PR TITLE
make package-url a go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/package-url/packageurl-go
+
+go 1.12


### PR DESCRIPTION
Fixes https://github.com/package-url/packageurl-go/issues/10

Requires Go 1.11+ to build.
If on GOPATH, set
`export GO111MODULE=on`.