### PR TITLE
Make PackageURL.ToString() deterministic.

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -72,8 +72,15 @@ var (
 	TypeRPM = "rpm"
 )
 
-// Qualifiers houses each key=value pair in the package url
-type Qualifiers map[string]string
+// Qualifier represents a single key=value qualifier in the package url
+type Qualifier struct {
+	Key   string
+	Value string
+}
+
+// Qualifiers is a slice of key=value pairs, with order preserved as it appears
+// in the package URL.
+type Qualifiers []Qualifier
 
 // PackageURL is the struct representation of the parts that make a package url
 type PackageURL struct {
@@ -121,10 +128,9 @@ func (p *PackageURL) ToString() string {
 	}
 
 	// Iterate over qualifiers and make groups of key=value
-	qualifiers := []string{}
-	for k, v := range p.Qualifiers {
-		// A value must be must be a percent-encoded string
-		qualifiers = append(qualifiers, fmt.Sprintf("%s=%s", k, url.PathEscape(v)))
+	var qualifiers []string
+	for _, q := range p.Qualifiers {
+		qualifiers = append(qualifiers, fmt.Sprintf("%s=%s", q.Key, q.Value))
 	}
 	// If there one or more key=value pairs then append on the package url
 	if len(qualifiers) != 0 {
@@ -135,6 +141,10 @@ func (p *PackageURL) ToString() string {
 		purl = purl + "#" + p.Subpath
 	}
 	return purl
+}
+
+func (p *PackageURL) String() string {
+	return p.ToString()
 }
 
 // FromString parses a valid package url string into a PackageURL structure
@@ -190,7 +200,7 @@ func FromString(purl string) (PackageURL, error) {
 			if err != nil {
 				return PackageURL{}, fmt.Errorf("failed to unescape qualifier value: %s", err)
 			}
-			qualifiers[key] = value
+			qualifiers = append(qualifiers, Qualifier{key, value})
 		}
 		remainder = remainder[:index]
 	}

--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -23,24 +23,100 @@ package packageurl_test
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"reflect"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/package-url/packageurl-go"
 )
 
 type TestFixture struct {
-	Description   string                `json:"description"`
-	Purl          string                `json:"purl"`
-	CanonicalPurl string                `json:"canonical_purl"`
-	PackageType   string                `json:"type"`
-	Namespace     string                `json:"namespace"`
-	Name          string                `json:"name"`
-	Version       string                `json:"version"`
-	Qualifiers    packageurl.Qualifiers `json:"qualifiers"`
-	Subpath       string                `json:"subpath"`
-	IsInvalid     bool                  `json:"is_invalid"`
+	Description   string     `json:"description"`
+	Purl          string     `json:"purl"`
+	CanonicalPurl string     `json:"canonical_purl"`
+	PackageType   string     `json:"type"`
+	Namespace     string     `json:"namespace"`
+	Name          string     `json:"name"`
+	Version       string     `json:"version"`
+	QualifierMap  OrderedMap `json:"qualifiers"`
+	Subpath       string     `json:"subpath"`
+	IsInvalid     bool       `json:"is_invalid"`
+}
+
+// OrderedMap is used to store the TestFixture.QualifierMap, to ensure that the
+// declaration order of qualifiers is preserved.
+type OrderedMap struct {
+	OrderedKeys []string
+	Map         map[string]string
+}
+
+// qualifiersMapPattern is used to parse the TestFixture "qualifiers" field to
+// ensure that it's a json object.
+var qualifiersMapPattern = regexp.MustCompile(`^\{.*\}$`)
+
+// UnmarshalJSON unmarshals the qualifiers field for a TestFixture. The
+// qualifiers field is given as a json object such as:
+//
+//        "qualifiers": {"arch": "i386", "distro": "fedora-25"}
+//
+// This function performs in-order parsing of these values into an OrderedMap to
+// preserve items in order of declaration. Note that parsing as a
+// map[string]string won't preserve element order.
+func (m *OrderedMap) UnmarshalJSON(bytes []byte) error {
+	data := string(bytes)
+	switch data {
+	case "null":
+		m.OrderedKeys = []string{}
+		m.Map = make(map[string]string, 0)
+		return nil
+	default:
+		// ensure that the data is a json object "{...}"
+		if !qualifiersMapPattern.MatchString(data) {
+			return fmt.Errorf("qualifiers parse error: not a json object: %s", data)
+		}
+
+		// find out the order in which map keys occur
+		dec := json.NewDecoder(strings.NewReader(data))
+		// consume opening '{'
+		_, _ = dec.Token()
+		for dec.More() {
+			t, _ := dec.Token()
+			switch token := t.(type) {
+			case json.Delim:
+				if token != '}' {
+					return fmt.Errorf("qualifiers parse error: expected delimiter '}', got: %v", token)
+				}
+				// closed json object -> we're done
+				break
+			case string:
+				// this token is a dictionary key
+				m.OrderedKeys = append(m.OrderedKeys, token)
+				// consume the value (the token following the colon after the key)
+				_, _ = dec.Token()
+			}
+		}
+
+		// now that we know the key order, just fill the OrderedMap.Map field
+		if err := json.Unmarshal(bytes, &m.Map); err != nil {
+			return err
+		}
+		return nil
+	}
+}
+
+// Qualifiers converts the TestFixture.QualifierMap field to an object of type
+// packageurl.Qualifiers.
+func (t TestFixture) Qualifiers() packageurl.Qualifiers {
+	q := packageurl.Qualifiers{}
+
+	for _, key := range t.QualifierMap.OrderedKeys {
+		q = append(q, packageurl.Qualifier{Key: key, Value: t.QualifierMap.Map[key]})
+	}
+
+	return q
 }
 
 // TestFromStringExamples verifies that parsing example strings produce expected
@@ -57,6 +133,7 @@ func TestFromStringExamples(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	// Use FromString on each item in the test set
 	for _, tc := range testData {
 		// Should parse without issue
@@ -98,7 +175,7 @@ func TestToStringExamples(t *testing.T) {
 		}
 		instance := packageurl.NewPackageURL(
 			tc.PackageType, tc.Namespace, tc.Name,
-			tc.Version, tc.Qualifiers, tc.Subpath)
+			tc.Version, tc.Qualifiers(), tc.Subpath)
 		result := instance.ToString()
 
 		// NOTE: We create a purl with ToString and then load into a PackageURL
@@ -109,6 +186,39 @@ func TestToStringExamples(t *testing.T) {
 		// If the two results don't equal then the ToString failed
 		if !reflect.DeepEqual(toTest, canonical) {
 			t.Logf("%s failed: %s != %s", tc.Description, result, tc.CanonicalPurl)
+			t.Fail()
+		}
+	}
+}
+
+// TestStringer verifies that the Stringer implementation produces results
+// equivalent with the ToString method.
+func TestStringer(t *testing.T) {
+	// Read the json file
+	data, err := ioutil.ReadFile("testdata/test-suite-data.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Load the json file contents into a structure
+	testData := []TestFixture{}
+	err = json.Unmarshal(data, &testData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Use ToString on each item
+	for _, tc := range testData {
+		// Skip invalid items
+		if tc.IsInvalid == true {
+			continue
+		}
+		instance := packageurl.NewPackageURL(
+			tc.PackageType, tc.Namespace, tc.Name,
+			tc.Version, tc.Qualifiers(), tc.Subpath)
+
+		// Verify that the Stringer implementation returns a result
+		// equivalent to ToString().
+		if instance.ToString() != instance.String() {
+			t.Logf("%s failed: Stringer implementation differs from ToString: %s != %s", tc.Description, instance.String(), instance.ToString())
 			t.Fail()
 		}
 	}


### PR DESCRIPTION
This commit offers a fix for https://github.com/package-url/packageurl-go/issues/5

A parsed PackageURL should preserve the order of qualifiers (as in the parsed URL) when output at a later time via ToString(). To do this, Qualifiers cannot make use of a regular map (keys are unordered).

    type Qualifiers map[string]string

This commit changes the type of Qualifiers into

    type Qualifiers []Qualifier

    type Qualifier struct {
        Key   string
        Value string
    }

to preserve qualifier ordering.

The tests are also updated to ensure that qualifiers are read in declaration-order from test-suite-data.json.

PackageURL is also made to implement the Stringer interface, which is idiomatic Go.