### PR TITLE
PackageURL.String() should use a value receiver rather than pointer receiver

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -186,7 +186,7 @@ func (p *PackageURL) ToString() string {
 	return purl
 }
 
-func (p *PackageURL) String() string {
+func (p PackageURL) String() string {
 	return p.ToString()
 }
 

--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -237,14 +237,22 @@ func TestStringer(t *testing.T) {
 		if tc.IsInvalid == true {
 			continue
 		}
-		instance := packageurl.NewPackageURL(
+		purlPtr := packageurl.NewPackageURL(
 			tc.PackageType, tc.Namespace, tc.Name,
 			tc.Version, tc.Qualifiers(), tc.Subpath)
+		purlValue := *purlPtr
 
 		// Verify that the Stringer implementation returns a result
 		// equivalent to ToString().
-		if instance.ToString() != instance.String() {
-			t.Logf("%s failed: Stringer implementation differs from ToString: %s != %s", tc.Description, instance.String(), instance.ToString())
+		if purlPtr.ToString() != purlPtr.String() {
+			t.Logf("%s failed: Stringer implementation differs from ToString: %s != %s", tc.Description, purlPtr.String(), purlPtr.ToString())
+			t.Fail()
+		}
+
+		// Verify that the %s format modifier works for values.
+		fmtStr := fmt.Sprintf("%s", purlValue)
+		if fmtStr != purlPtr.String() {
+			t.Logf("%s failed: %%s format modifier does not work on values: %s != %s", tc.Description, fmtStr, purlPtr.ToString())
 			t.Fail()
 		}
 	}


### PR DESCRIPTION
make `PackageURL.String()` use a value receiver rather than pointer receiver.

This makes

     fmt.Sprintf("%s", packageurl.FromString("pkg:maven/org.yaml/snakeyaml@1.24"))

output the expected

     "pkg:maven/org.yaml/snakeyaml@1.24"

rather than

     "{maven org.yaml snakeyaml 1.24  }"


As it stands, with `String()` using a pointer receiver one needs to:

     purl := packageurl.FromString("pkg:maven/org.yaml/snakeyaml@1.24")   
     fmt.Sprintf("%s", &purl)

to get the intended output.