### PR TITLE
Replace debian type with deb

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -50,7 +50,7 @@ var (
 	// TypeComposer is a pkg:composer purl.
 	TypeComposer = "composer"
 	// TypeDebian is a pkg:deb purl.
-	TypeDebian = "debian"
+	TypeDebian = "deb"
 	// TypeDocker is a pkg:docker purl.
 	TypeDocker = "docker"
 	// TypeGem is a pkg:gem purl.


### PR DESCRIPTION
Per the spec the `TypeDebian` value should be `deb` (which would render `pkg:deb/...`) otherwise the `TypeDebian` value is not useful (rendering to `pkg:debian/...`).