### PR TITLE
add type for Rust cargo package urls

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -47,6 +47,8 @@ var (
 var (
 	// TypeBitbucket is a pkg:bitbucket purl.
 	TypeBitbucket = "bitbucket"
+	// TypeCargo is a pkg:cargo purl.
+	TypeCargo = "cargo"
 	// TypeComposer is a pkg:composer purl.
 	TypeComposer = "composer"
 	// TypeDebian is a pkg:deb purl.


### PR DESCRIPTION
Adds a type for Rust cargo package urls per https://github.com/package-url/purl-spec#known-purl-types