### PR TITLE
Remove the mit.LICENSE symlink

### DIFF
--- a/mit.LICENSE
+++ b/mit.LICENSE
@@ -1,1 +1,0 @@
-LICENSE


### PR DESCRIPTION
The module docs are not displayed on pkg.go.dev, because of lincese issues, even though the MIT license is supported.

It might be because of the symlink.
Thanks @imjasonh for reporting the issues and for the suggested fix.

Possibly fixes #33

Signed-off-by: Andrea Frittoli <andrea.frittoli@gmail.com>