### PR TITLE
Dont download test data

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,8 +14,6 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Download test data
-        run: curl -L https://raw.githubusercontent.com/package-url/purl-spec/master/test-suite-data.json -o testdata/test-suite-data.json
       - name: Test go fmt
         run: test -z $(go fmt ./...)
       - name: Golangci-lint

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,7 @@
 .PHONY: test clean lint
 
 test:
-	curl -L https://raw.githubusercontent.com/package-url/purl-spec/master/test-suite-data.json -o testdata/test-suite-data.json
 	go test -v -cover ./...
-
-clean:
-	find . -name "test-suite-data.json" | xargs rm -f
 
 lint:
 	go get -u golang.org/x/lint/golint

--- a/README.md
+++ b/README.md
@@ -59,10 +59,6 @@ Testing using the normal ``go test`` command. Using ``make test`` will pull the 
 
 ```
 $ make test
-curl -L https://raw.githubusercontent.com/package-url/purl-test-suite/master/test-suite-data.json -o testdata/test-suite-data.json
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100  7181  100  7181    0     0   1202      0  0:00:05  0:00:05 --:--:--  1611
 go test -v -cover ./...
 === RUN   TestFromStringExamples
 --- PASS: TestFromStringExamples (0.00s)


### PR DESCRIPTION
[This pr](https://github.com/package-url/packageurl-go/pull/32) added the test data file directly to this repo, so we don't need to download it anymore

However, im not sure if my PR here is valid. The test data in this repo is different than the test data being pulled at https://raw.githubusercontent.com/package-url/purl-spec/master/test-suite-data.json

Is the test data in this repo the on we really want to use, or should we actually just fetch from github.com/package-url/purl-spec?