### PR TITLE
feat: add missing purl types

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -45,6 +45,10 @@ var (
 // special treatment during parsing.
 // https://github.com/package-url/purl-spec#known-purl-types
 var (
+	// TypeAlpm is a pkg:alpm purl.
+	TypeAlpm = "alpm"
+	// TypeApk is a pkg:apk purl.
+	TypeApk = "apk"
 	// TypeBitbucket is a pkg:bitbucket purl.
 	TypeBitbucket = "bitbucket"
 	// TypeCocoapods is a pkg:cocoapods purl.
@@ -81,12 +85,16 @@ var (
 	TypeNPM = "npm"
 	// TypeNuget is a pkg:nuget purl.
 	TypeNuget = "nuget"
+	// TypeQPKG is a pkg:qpkg purl.
+	TypeQpkg = "qpkg"
 	// TypeOCI is a pkg:oci purl
 	TypeOCI = "oci"
 	// TypePyPi is a pkg:pypi purl.
 	TypePyPi = "pypi"
 	// TypeRPM is a pkg:rpm purl.
 	TypeRPM = "rpm"
+	// TypeSWID is pkg:swid purl
+	TypeSWID = "swid"
 	// TypeSwift is pkg:swift purl
 	TypeSwift = "swift"
 	// TypeHuggingface is pkg:huggingface purl.
@@ -348,7 +356,16 @@ func FromString(purl string) (PackageURL, error) {
 // See https://github.com/package-url/purl-spec#known-purl-types
 func typeAdjustNamespace(purlType, ns string) string {
 	switch purlType {
-	case TypeBitbucket, TypeDebian, TypeGithub, TypeGolang, TypeNPM, TypeRPM, TypeComposer:
+	case TypeAlpm,
+		TypeApk,
+		TypeBitbucket,
+		TypeComposer,
+		TypeDebian,
+		TypeGithub,
+		TypeGolang,
+		TypeNPM,
+		TypeRPM,
+		TypeQpkg:
 		return strings.ToLower(ns)
 	}
 	return ns
@@ -359,7 +376,14 @@ func typeAdjustNamespace(purlType, ns string) string {
 func typeAdjustName(purlType, name string, qualifiers Qualifiers) string {
 	quals := qualifiers.Map()
 	switch purlType {
-	case TypeBitbucket, TypeDebian, TypeGithub, TypeGolang, TypeNPM, TypeComposer:
+	case TypeAlpm,
+		TypeApk,
+		TypeBitbucket,
+		TypeComposer,
+		TypeDebian,
+		TypeGithub,
+		TypeGolang,
+		TypeNPM:
 		return strings.ToLower(name)
 	case TypePyPi:
 		return strings.ToLower(strings.ReplaceAll(name, "_", "-"))

--- a/testdata/test-suite-data.json
+++ b/testdata/test-suite-data.json
@@ -562,5 +562,77 @@
     "qualifiers": null,
     "subpath": null,
     "is_invalid": false
+  },
+  {
+    "description": "valid alpm purl",
+    "purl": "pkg:alpm/arch/pacman@6.0.1-1?arch=x86_64",
+    "canonical_purl": "pkg:alpm/arch/pacman@6.0.1-1?arch=x86_64",
+    "type": "alpm",
+    "namespace": "arch",
+    "name": "pacman",
+    "version": "6.0.1-1",
+    "qualifiers": {"arch": "x86_64"},
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "alpm namespace and name should be lowercased",
+    "purl": "pkg:alpm/Arch/PacMan@6.0.1-1?arch=x86_64",
+    "canonical_purl": "pkg:alpm/arch/pacman@6.0.1-1?arch=x86_64",
+    "type": "alpm",
+    "namespace": "arch",
+    "name": "pacman",
+    "version": "6.0.1-1",
+    "qualifiers": {"arch": "x86_64"},
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "valid apk purl",
+    "purl": "pkg:apk/alpine/curl@7.83.0-r0?arch=x86_64",
+    "canonical_purl": "pkg:apk/alpine/curl@7.83.0-r0?arch=x86_64",
+    "type": "apk",
+    "namespace": "alpine",
+    "name": "curl",
+    "version": "7.83.0-r0",
+    "qualifiers": {"arch": "x86_64"},
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "apk namespace and name should be lowercased",
+    "purl": "pkg:apk/Alpine/Curl@7.83.0-r0?arch=x86_64",
+    "canonical_purl": "pkg:apk/alpine/curl@7.83.0-r0?arch=x86_64",
+    "type": "apk",
+    "namespace": "alpine",
+    "name": "curl",
+    "version": "7.83.0-r0",
+    "qualifiers": {"arch": "x86_64"},
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "valid qpkg purl",
+    "purl": "pkg:qpkg/blackberry/com.qnx.sdp@7.0.0.SGA201702151847",
+    "canonical_purl": "pkg:qpkg/blackberry/com.qnx.sdp@7.0.0.SGA201702151847",
+    "type": "qpkg",
+    "namespace": "blackberry",
+    "name": "com.qnx.sdp",
+    "version": "7.0.0.SGA201702151847",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
+  },
+  {
+    "description": "qpkg namespace should be lowercased",
+    "purl": "pkg:qpkg/BlackBerry/com.qnx.sdp@7.0.0.SGA201702151847",
+    "canonical_purl": "pkg:qpkg/blackberry/com.qnx.sdp@7.0.0.SGA201702151847",
+    "type": "qpkg",
+    "namespace": "blackberry",
+    "name": "com.qnx.sdp",
+    "version": "7.0.0.SGA201702151847",
+    "qualifiers": null,
+    "subpath": null,
+    "is_invalid": false
   }
 ]


### PR DESCRIPTION
We are missing support for a few Package URL types in this lib, so I referenced [the list of known `purl` types](https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#known-purl-types) and added the ones that were not implemented yet.

This adds `purl` types `alpm`, `apk`, ~~`huggingface`~~, ~~`mlflow`~~, `qpkg`, ~~`pub` and `swid`~~.