### PR TITLE
Test using supported Go versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.19.x, 1.20.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Go 1.19 and 1.20 are the only currently supported versions. 1.21 will be out soon, at which point 1.19 will no longer be supported.

This might require some behind-the-scenes button-clicking to make the existing checks not required, so this can merge.