### PR TITLE
fix: use url.Values for Qualifiers

### DIFF
--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -23,98 +23,31 @@ package packageurl_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 	"reflect"
-	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/package-url/packageurl-go"
 )
 
 type TestFixture struct {
-	Description   string     `json:"description"`
-	Purl          string     `json:"purl"`
-	CanonicalPurl string     `json:"canonical_purl"`
-	PackageType   string     `json:"type"`
-	Namespace     string     `json:"namespace"`
-	Name          string     `json:"name"`
-	Version       string     `json:"version"`
-	QualifierMap  OrderedMap `json:"qualifiers"`
-	Subpath       string     `json:"subpath"`
-	IsInvalid     bool       `json:"is_invalid"`
+	Description   string            `json:"description"`
+	Purl          string            `json:"purl"`
+	CanonicalPurl string            `json:"canonical_purl"`
+	PackageType   string            `json:"type"`
+	Namespace     string            `json:"namespace"`
+	Name          string            `json:"name"`
+	Version       string            `json:"version"`
+	QualifierMap  map[string]string `json:"qualifiers"`
+	Subpath       string            `json:"subpath"`
+	IsInvalid     bool              `json:"is_invalid"`
 }
 
-// OrderedMap is used to store the TestFixture.QualifierMap, to ensure that the
-// declaration order of qualifiers is preserved.
-type OrderedMap struct {
-	OrderedKeys []string
-	Map         map[string]string
-}
-
-// qualifiersMapPattern is used to parse the TestFixture "qualifiers" field to
-// ensure that it's a json object.
-var qualifiersMapPattern = regexp.MustCompile(`(?ms)^\{.*\}$`)
-
-// UnmarshalJSON unmarshals the qualifiers field for a TestFixture. The
-// qualifiers field is given as a json object such as:
-//
-//	"qualifiers": {"arch": "i386", "distro": "fedora-25"}
-//
-// This function performs in-order parsing of these values into an OrderedMap to
-// preserve items in order of declaration. Note that parsing as a
-// map[string]string won't preserve element order.
-func (m *OrderedMap) UnmarshalJSON(bytes []byte) error {
-	data := string(bytes)
-	switch data {
-	case "null":
-		m.OrderedKeys = []string{}
-		m.Map = make(map[string]string)
-		return nil
-	default:
-		// ensure that the data is a json object "{...}"
-		if !qualifiersMapPattern.MatchString(data) {
-			return fmt.Errorf("qualifiers parse error: not a json object: %s", data)
-		}
-
-		// find out the order in which map keys occur
-		dec := json.NewDecoder(strings.NewReader(data))
-		// consume opening '{'
-		_, _ = dec.Token()
-		for dec.More() {
-			t, _ := dec.Token()
-			switch token := t.(type) {
-			case json.Delim:
-				if token != '}' {
-					return fmt.Errorf("qualifiers parse error: expected delimiter '}', got: %v", token)
-				}
-				// closed json object -> we're done
-			case string:
-				// this token is a dictionary key
-				m.OrderedKeys = append(m.OrderedKeys, token)
-				// consume the value (the token following the colon after the key)
-				_, _ = dec.Token()
-			}
-		}
-
-		// now that we know the key order, just fill the OrderedMap.Map field
-		if err := json.Unmarshal(bytes, &m.Map); err != nil {
-			return err
-		}
-		return nil
-	}
-}
-
-// Qualifiers converts the TestFixture.QualifierMap field to an object of type
-// packageurl.Qualifiers.
 func (t TestFixture) Qualifiers() packageurl.Qualifiers {
 	q := packageurl.Qualifiers{}
-
-	for _, key := range t.QualifierMap.OrderedKeys {
-		q = append(q, packageurl.Qualifier{Key: key, Value: t.QualifierMap.Map[key]})
+	for k, v := range t.QualifierMap {
+		q.Add(k, v)
 	}
-
 	return q
 }
 
@@ -200,8 +133,7 @@ func TestToStringExamples(t *testing.T) {
 		}
 		instance := packageurl.NewPackageURL(
 			tc.PackageType, tc.Namespace, tc.Name, tc.Version,
-			// Use QualifiersFromMap so that the qualifiers have a defined order, which is needed for string comparisons
-			packageurl.QualifiersFromMap(tc.Qualifiers().Map()), tc.Subpath)
+			tc.Qualifiers(), tc.Subpath)
 		result := instance.ToString()
 
 		// NOTE: We create a purl with ToString and then load into a PackageURL
@@ -253,48 +185,6 @@ func TestStringer(t *testing.T) {
 		fmtStr := purlValue.String()
 		if fmtStr != purlPtr.String() {
 			t.Logf("%s failed: %%s format modifier does not work on values: %s != %s", tc.Description, fmtStr, purlPtr.ToString())
-			t.Fail()
-		}
-	}
-}
-
-// Verify correct conversion of Qualifiers to a string map and vice versa.
-func TestQualifiersMapConversion(t *testing.T) {
-	tests := []struct {
-		kvMap      map[string]string
-		qualifiers packageurl.Qualifiers
-	}{
-		{
-			kvMap:      map[string]string{},
-			qualifiers: packageurl.Qualifiers{},
-		},
-		{
-			kvMap: map[string]string{"arch": "amd64"},
-			qualifiers: packageurl.Qualifiers{
-				packageurl.Qualifier{Key: "arch", Value: "amd64"},
-			},
-		},
-		{
-			kvMap: map[string]string{"arch": "amd64", "os": "linux"},
-			qualifiers: packageurl.Qualifiers{
-				packageurl.Qualifier{Key: "arch", Value: "amd64"},
-				packageurl.Qualifier{Key: "os", Value: "linux"},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		// map -> Qualifiers
-		got := packageurl.QualifiersFromMap(test.kvMap)
-		if !reflect.DeepEqual(got, test.qualifiers) {
-			t.Logf("map -> qualifiers conversion failed: got: %#v, wanted: %#v", got, test.qualifiers)
-			t.Fail()
-		}
-
-		// Qualifiers -> map
-		mp := test.qualifiers.Map()
-		if !reflect.DeepEqual(mp, test.kvMap) {
-			t.Logf("qualifiers -> map conversion failed: got: %#v, wanted: %#v", mp, test.kvMap)
 			t.Fail()
 		}
 	}


### PR DESCRIPTION
BREAKING CHANGE: This commit removes all the custom qualifier-logic that existed in order to keep the ordering of the qualifiers. The spec says:

> sort this list of qualifier strings lexicographically

However, it doesn't say anything about the ordering within the typed representation.

Using `url.Values` through a type alias gives users an easier way to access specific values and removes code that we now don't need to maintain anymore.

See #53 for more information.

#53 briefly touches on the release process as well. Because this library is still in alpha-release (`v0.x.y`), I don't think we need to bump the major version. Releasing a `v0.2.0` would be fine according to the SemVer rules.

I'm aware that this is quite a big change to the API, but I think better now than later :) 