### PR TITLE
fix: escape everything with modified QueryEscape

### DIFF
--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -302,12 +302,12 @@ func TestQualifiersMapConversion(t *testing.T) {
 
 func TestNameEscaping(t *testing.T) {
 	testCases := map[string]string{
-		"abc":  "pkg:abc",
-		"ab/c": "pkg:ab%2Fc",
+		"abc":  "pkg:deb/abc",
+		"ab/c": "pkg:deb/ab%2Fc",
 	}
 	for name, output := range testCases {
 		t.Run(name, func(t *testing.T) {
-			p := &packageurl.PackageURL{Name: name}
+			p := &packageurl.PackageURL{Type: "deb", Name: name}
 			if s := p.ToString(); s != output {
 				t.Fatalf("wrong escape. expected=%q, got=%q", output, s)
 			}


### PR DESCRIPTION
This commit switches to using `QueryEscape` for escaping all components. However, because `QueryEscape` escapes ` ` (space) to `+`, we actually change that to a `%20`, that is the percent-encoded equivalent.

`QueryEscape` was built for HTTP Query parameters, and although there is [some discussion](https://stackoverflow.com/questions/2678551/when-should-space-be-encoded-to-plus-or-20) around it, escaping ` ` to a `+` is completely valid. Sadly, other languages / implementations like the Javascript one don't handle that properly, so if we simply used `QueryEscape`, the purl couldn't be parsed by other implementations.
By using the universally supported `%20` instead, we restore compatibility.