### PR TITLE
Add `pub` and `bitnami` types

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -52,10 +52,10 @@ var (
 	TypeApk = "apk"
 	// TypeBitbucket is a pkg:bitbucket purl.
 	TypeBitbucket = "bitbucket"
-	// TypeCocoapods is a pkg:cocoapods purl.
-	TypeCocoapods = "cocoapods"
 	// TypeCargo is a pkg:cargo purl.
 	TypeCargo = "cargo"
+	// TypeCocoapods is a pkg:cocoapods purl.
+	TypeCocoapods = "cocoapods"
 	// TypeComposer is a pkg:composer purl.
 	TypeComposer = "composer"
 	// TypeConan is a pkg:conan purl.
@@ -80,30 +80,30 @@ var (
 	TypeHackage = "hackage"
 	// TypeHex is a pkg:hex purl.
 	TypeHex = "hex"
+	// TypeHuggingface is pkg:huggingface purl.
+	TypeHuggingface = "huggingface"
+	// TypeJulia is a pkg:julia purl
+	TypeJulia = "julia"
+	// TypeMLflow is pkg:mlflow purl.
+	TypeMLFlow = "mlflow"
 	// TypeMaven is a pkg:maven purl.
 	TypeMaven = "maven"
 	// TypeNPM is a pkg:npm purl.
 	TypeNPM = "npm"
 	// TypeNuget is a pkg:nuget purl.
 	TypeNuget = "nuget"
-	// TypeQPKG is a pkg:qpkg purl.
-	TypeQpkg = "qpkg"
 	// TypeOCI is a pkg:oci purl
 	TypeOCI = "oci"
 	// TypePyPi is a pkg:pypi purl.
 	TypePyPi = "pypi"
+	// TypeQPKG is a pkg:qpkg purl.
+	TypeQpkg = "qpkg"
 	// TypeRPM is a pkg:rpm purl.
 	TypeRPM = "rpm"
 	// TypeSWID is pkg:swid purl
 	TypeSWID = "swid"
 	// TypeSwift is pkg:swift purl
 	TypeSwift = "swift"
-	// TypeHuggingface is pkg:huggingface purl.
-	TypeHuggingface = "huggingface"
-	// TypeMLflow is pkg:mlflow purl.
-	TypeMLFlow = "mlflow"
-	// TypeJulia is a pkg:julia purl
-	TypeJulia = "julia"
 )
 
 // Qualifier represents a single key=value qualifier in the package url

--- a/packageurl.go
+++ b/packageurl.go
@@ -52,6 +52,8 @@ var (
 	TypeApk = "apk"
 	// TypeBitbucket is a pkg:bitbucket purl.
 	TypeBitbucket = "bitbucket"
+	// TypeBitnami is a pkg:bitnami purl.
+	TypeBitnami = "bitnami"
 	// TypeCargo is a pkg:cargo purl.
 	TypeCargo = "cargo"
 	// TypeCocoapods is a pkg:cocoapods purl.
@@ -94,6 +96,8 @@ var (
 	TypeNuget = "nuget"
 	// TypeOCI is a pkg:oci purl
 	TypeOCI = "oci"
+	// TypePub is a pkg:pub purl.
+	TypePub = "pub"
 	// TypePyPi is a pkg:pypi purl.
 	TypePyPi = "pypi"
 	// TypeQPKG is a pkg:qpkg purl.
@@ -379,6 +383,7 @@ func typeAdjustName(purlType, name string, qualifiers Qualifiers) string {
 	case TypeAlpm,
 		TypeApk,
 		TypeBitbucket,
+		TypeBitnami,
 		TypeComposer,
 		TypeDebian,
 		TypeGithub,


### PR DESCRIPTION
This PR is just to add the recently introduced `pub` ([info](https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#pub)) and `bitnami` ([info](https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#bitnami)) types in the repo.

Besides, I have sorted the existing types alphabetically, that's why the additional changes in the diff.