### PR TITLE
Add known types and candidate types

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -52,6 +52,8 @@ var (
 	TypeApk = "apk"
 	// TypeBitbucket is a pkg:bitbucket purl.
 	TypeBitbucket = "bitbucket"
+	// TypeBitnami is a pkg:bitnami purl.
+	TypeBitnami = "bitnami"
 	// TypeCargo is a pkg:cargo purl.
 	TypeCargo = "cargo"
 	// TypeCocoapods is a pkg:cocoapods purl.
@@ -94,6 +96,8 @@ var (
 	TypeNuget = "nuget"
 	// TypeOCI is a pkg:oci purl
 	TypeOCI = "oci"
+	// TypePub is a pkg:pub purl.
+	TypePub = "pub"
 	// TypePyPi is a pkg:pypi purl.
 	TypePyPi = "pypi"
 	// TypeQPKG is a pkg:qpkg purl.
@@ -363,6 +367,7 @@ func typeAdjustName(purlType, name string, qualifiers Qualifiers) string {
 	case TypeAlpm,
 		TypeApk,
 		TypeBitbucket,
+		TypeBitnami,
 		TypeComposer,
 		TypeDebian,
 		TypeGithub,

--- a/packageurl.go
+++ b/packageurl.go
@@ -52,10 +52,10 @@ var (
 	TypeApk = "apk"
 	// TypeBitbucket is a pkg:bitbucket purl.
 	TypeBitbucket = "bitbucket"
-	// TypeCocoapods is a pkg:cocoapods purl.
-	TypeCocoapods = "cocoapods"
 	// TypeCargo is a pkg:cargo purl.
 	TypeCargo = "cargo"
+	// TypeCocoapods is a pkg:cocoapods purl.
+	TypeCocoapods = "cocoapods"
 	// TypeComposer is a pkg:composer purl.
 	TypeComposer = "composer"
 	// TypeConan is a pkg:conan purl.
@@ -80,30 +80,30 @@ var (
 	TypeHackage = "hackage"
 	// TypeHex is a pkg:hex purl.
 	TypeHex = "hex"
+	// TypeHuggingface is pkg:huggingface purl.
+	TypeHuggingface = "huggingface"
+	// TypeJulia is a pkg:julia purl
+	TypeJulia = "julia"
+	// TypeMLflow is pkg:mlflow purl.
+	TypeMLFlow = "mlflow"
 	// TypeMaven is a pkg:maven purl.
 	TypeMaven = "maven"
 	// TypeNPM is a pkg:npm purl.
 	TypeNPM = "npm"
 	// TypeNuget is a pkg:nuget purl.
 	TypeNuget = "nuget"
-	// TypeQPKG is a pkg:qpkg purl.
-	TypeQpkg = "qpkg"
 	// TypeOCI is a pkg:oci purl
 	TypeOCI = "oci"
 	// TypePyPi is a pkg:pypi purl.
 	TypePyPi = "pypi"
+	// TypeQPKG is a pkg:qpkg purl.
+	TypeQpkg = "qpkg"
 	// TypeRPM is a pkg:rpm purl.
 	TypeRPM = "rpm"
 	// TypeSWID is pkg:swid purl
 	TypeSWID = "swid"
 	// TypeSwift is pkg:swift purl
 	TypeSwift = "swift"
-	// TypeHuggingface is pkg:huggingface purl.
-	TypeHuggingface = "huggingface"
-	// TypeMLflow is pkg:mlflow purl.
-	TypeMLFlow = "mlflow"
-	// TypeJulia is a pkg:julia purl
-	TypeJulia = "julia"
 )
 
 // Qualifier represents a single key=value qualifier in the package url

--- a/packageurl.go
+++ b/packageurl.go
@@ -84,8 +84,6 @@ var (
 	TypeHex = "hex"
 	// TypeHuggingface is pkg:huggingface purl.
 	TypeHuggingface = "huggingface"
-	// TypeJulia is a pkg:julia purl
-	TypeJulia = "julia"
 	// TypeMLflow is pkg:mlflow purl.
 	TypeMLFlow = "mlflow"
 	// TypeMaven is a pkg:maven purl.
@@ -108,6 +106,144 @@ var (
 	TypeSWID = "swid"
 	// TypeSwift is pkg:swift purl
 	TypeSwift = "swift"
+
+	// KnownTypes is a map of types that are officially supported by the spec.
+	// See https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#known-purl-types
+	KnownTypes = map[string]struct{}{
+		TypeAlpm:        {},
+		TypeApk:         {},
+		TypeBitbucket:   {},
+		TypeBitnami:     {},
+		TypeCargo:       {},
+		TypeCocoapods:   {},
+		TypeComposer:    {},
+		TypeConan:       {},
+		TypeConda:       {},
+		TypeCran:        {},
+		TypeDebian:      {},
+		TypeDocker:      {},
+		TypeGem:         {},
+		TypeGeneric:     {},
+		TypeGithub:      {},
+		TypeGolang:      {},
+		TypeHackage:     {},
+		TypeHex:         {},
+		TypeHuggingface: {},
+		TypeMaven:       {},
+		TypeMLFlow:      {},
+		TypeNPM:         {},
+		TypeNuget:       {},
+		TypeOCI:         {},
+		TypePub:         {},
+		TypePyPi:        {},
+		TypeQpkg:        {},
+		TypeRPM:         {},
+		TypeSWID:        {},
+		TypeSwift:       {},
+	}
+
+	TypeApache      = "apache"
+	TypeAndroid     = "android"
+	TypeAtom        = "atom"
+	TypeBower       = "bower"
+	TypeBrew        = "brew"
+	TypeBuildroot   = "buildroot"
+	TypeCarthage    = "carthage"
+	TypeChef        = "chef"
+	TypeChocolatey  = "chocolatey"
+	TypeClojars     = "clojars"
+	TypeCoreos      = "coreos"
+	TypeCpan        = "cpan"
+	TypeCtan        = "ctan"
+	TypeCrystal     = "crystal"
+	TypeDrupal      = "drupal"
+	TypeDtype       = "dtype"
+	TypeDub         = "dub"
+	TypeElm         = "elm"
+	TypeEclipse     = "eclipse"
+	TypeGitea       = "gitea"
+	TypeGitlab      = "gitlab"
+	TypeGradle      = "gradle"
+	TypeGuix        = "guix"
+	TypeHaxe        = "haxe"
+	TypeHelm        = "helm"
+	TypeJulia       = "julia"
+	TypeLua         = "lua"
+	TypeMelpa       = "melpa"
+	TypeMeteor      = "meteor"
+	TypeNim         = "nim"
+	TypeNix         = "nix"
+	TypeOpam        = "opam"
+	TypeOpenwrt     = "openwrt"
+	TypeOsgi        = "osgi"
+	TypeP2          = "p2"
+	TypePear        = "pear"
+	TypePecl        = "pecl"
+	TypePERL6       = "perl6"
+	TypePlatformio  = "platformio"
+	TypeEbuild      = "ebuild"
+	TypePuppet      = "puppet"
+	TypeSourceforge = "sourceforge"
+	TypeSublime     = "sublime"
+	TypeTerraform   = "terraform"
+	TypeVagrant     = "vagrant"
+	TypeVim         = "vim"
+	TypeWORDPRESS   = "wordpress"
+	TypeYocto       = "yocto"
+
+	// CandidateTypes is a map of types that are not yet officially supported by the spec,
+	// but are being considered for inclusion.
+	// See https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#other-candidate-types-to-define
+	CandidateTypes = map[string]struct{}{
+		TypeApache:      {},
+		TypeAndroid:     {},
+		TypeAtom:        {},
+		TypeBower:       {},
+		TypeBrew:        {},
+		TypeBuildroot:   {},
+		TypeCarthage:    {},
+		TypeChef:        {},
+		TypeChocolatey:  {},
+		TypeClojars:     {},
+		TypeCoreos:      {},
+		TypeCpan:        {},
+		TypeCtan:        {},
+		TypeCrystal:     {},
+		TypeDrupal:      {},
+		TypeDtype:       {},
+		TypeDub:         {},
+		TypeElm:         {},
+		TypeEclipse:     {},
+		TypeGitea:       {},
+		TypeGitlab:      {},
+		TypeGradle:      {},
+		TypeGuix:        {},
+		TypeHaxe:        {},
+		TypeHelm:        {},
+		TypeJulia:       {},
+		TypeLua:         {},
+		TypeMelpa:       {},
+		TypeMeteor:      {},
+		TypeNim:         {},
+		TypeNix:         {},
+		TypeOpam:        {},
+		TypeOpenwrt:     {},
+		TypeOsgi:        {},
+		TypeP2:          {},
+		TypePear:        {},
+		TypePecl:        {},
+		TypePERL6:       {},
+		TypePlatformio:  {},
+		TypeEbuild:      {},
+		TypePuppet:      {},
+		TypeSourceforge: {},
+		TypeSublime:     {},
+		TypeTerraform:   {},
+		TypeVagrant:     {},
+		TypeVim:         {},
+		TypeWORDPRESS:   {},
+		TypeYocto:       {},
+	}
 )
 
 // Qualifier represents a single key=value qualifier in the package url


### PR DESCRIPTION
This PR is adding the `KnownTypes`  as a way to easily check which packages types are officially supported/present in the spec. Besides, I've added the `CandidateTypes` for holding those packages that are considered to be included ([more info](https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#other-candidate-types-to-define)).
The rationale behind this PR is described at #59.

Note that `TypeJulia` was moved to `CandidateTypes` (even if it was priorly defined in the repo) because it does not appear in the official spec yet.

Requires #60 to be merged beforehand (as some additional types were added).

Closes #59