### PR TITLE
Add PackageURL.Normalize

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -482,11 +482,14 @@ func parseQualifiers(rawQuery string) (Qualifiers, error) {
 			return nil, fmt.Errorf("error unescaping qualifier value %q", value)
 		}
 
-		q = append(q, Qualifier{
-			Key: strings.ToLower(key),
+		if len(value) > 0 {
 			// only the first character needs  to be lowercase. Note that pURL is always UTF8, so we
 			// don't need to care about unicode here.
-			Value: strings.ToLower(value[:1]) + value[1:],
+			value = strings.ToLower(value[:1]) + value[1:]
+		}
+		q = append(q, Qualifier{
+			Key:   strings.ToLower(key),
+			Value: value,
 		})
 	}
 	return q, nil

--- a/packageurl.go
+++ b/packageurl.go
@@ -477,11 +477,6 @@ func parseQualifiers(rawQuery string) (Qualifiers, error) {
 			return nil, fmt.Errorf("invalid qualifier key: '%s'", key)
 		}
 
-		value, err = url.QueryUnescape(value)
-		if err != nil {
-			return nil, fmt.Errorf("error unescaping qualifier value %q", value)
-		}
-
 		if len(value) > 0 {
 			// only the first character needs  to be lowercase. Note that pURL is always UTF8, so we
 			// don't need to care about unicode here.

--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -315,3 +315,19 @@ func TestNameEscaping(t *testing.T) {
 	}
 
 }
+
+func TestQualifierMissingEqual(t *testing.T) {
+	input := "pkg:npm/test-pkg?key"
+	want := packageurl.PackageURL{
+		Type:       "npm",
+		Name:       "test-pkg",
+		Qualifiers: packageurl.Qualifiers{{Key: "key"}},
+	}
+	got, err := packageurl.FromString(input)
+	if err != nil {
+		t.Fatalf("FromString(%s): unexpected error: %v", input, err)
+	}
+	if !reflect.DeepEqual(want, got) {
+		t.Fatalf("FromString(%s): want %q got %q", input, want, got)
+	}
+}


### PR DESCRIPTION
For many integrations external systems use their own structured
representation of package identifiers rather than Package URLs. In
these cases it would be ideal to construct a Package URL with with
NewPackageURL a then normalize the resulting struct. It avoids the
need to render a temporary, non-canon Package URL and parse that to
achieve normalization.