### PR TITLE
go.mod: Bump required Go version to 1.18

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.18.x, 1.19.x, 1.20.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/package-url/packageurl-go
 
-go 1.17
+go 1.18


### PR DESCRIPTION
Commit 564b6fc1cff67081fc32f41eaedbd2fa16789c27 introduced calls to strings.Cut, added in Go 1.18, so updating go.mod accordingly. The fuzz testing also requires 1.18 but that will at least not affect users of the module. Also updating the CI configuration to actually test the Go version we claim to support.