### PR TITLE
Adds `./` and `../` as valid subpath prefix

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -457,8 +457,8 @@ func (p *PackageURL) Normalize() error {
 	}
 	subpath := strings.Trim(p.Subpath, "/")
 	segs := strings.Split(p.Subpath, "/")
-	for _, s := range segs {
-		if s == "." || s == ".." {
+	for i, s := range segs {
+		if (s == "." || s == "..") && i != 0 {
 			return fmt.Errorf("invalid Package URL subpath: %q", p.Subpath)
 		}
 	}

--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -487,6 +487,19 @@ func TestNormalize(t *testing.T) {
 		},
 		wantErr: true,
 	}, {
+		name: "'./' is a valid subpath prefix",
+		input: packageurl.PackageURL{
+			Type:    "npm",
+			Name:    "pkg",
+			Subpath: "./sub/path",
+		},
+		want: packageurl.PackageURL{
+			Type:       "npm",
+			Name:       "pkg",
+			Qualifiers: packageurl.Qualifiers{},
+			Subpath:    "./sub/path",
+		},
+	}, {
 		name: "known type namespace adjustments",
 		input: packageurl.PackageURL{
 			Type:      "npm",

--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -500,6 +500,19 @@ func TestNormalize(t *testing.T) {
 			Subpath:    "./sub/path",
 		},
 	}, {
+		name: "'../' is a valid subpath prefix",
+		input: packageurl.PackageURL{
+			Type:    "npm",
+			Name:    "pkg",
+			Subpath: "../sub/path",
+		},
+		want: packageurl.PackageURL{
+			Type:       "npm",
+			Name:       "pkg",
+			Qualifiers: packageurl.Qualifiers{},
+			Subpath:    "../sub/path",
+		},
+	}, {
 		name: "known type namespace adjustments",
 		input: packageurl.PackageURL{
 			Type:      "npm",


### PR DESCRIPTION
Closes #67.

Checks if `./` and `../` are the first segment in the subpath, if they are, proceed. Otherwise, throw the invalid error