### PR TITLE
Fix Github Actions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.18.x, 1.19.x, 1.20.x]
+        go-version: [1.21.x, 1.22.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -29,7 +29,7 @@ jobs:
         env:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          GO111MODULE=off go get github.com/mattn/goveralls
+          go install github.com/mattn/goveralls@latest
           $(go env GOPATH)/bin/goveralls -coverprofile=profile.cov -service=github
 
       - name: Fuzz tests


### PR DESCRIPTION
This commit fixes our Github actions pipeline via using `go install` instead of `go get`. Moreover, we only support the last two Go releases from now on. This is compliant to: https://go.dev/doc/devel/release