### PR TITLE
Allow npm names to be case sensitive

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -566,7 +566,6 @@ func typeAdjustNamespace(purlType, ns string) string {
 		TypeDebian,
 		TypeGithub,
 		TypeGolang,
-		TypeNPM,
 		TypeRPM,
 		TypeQpkg:
 		return strings.ToLower(ns)

--- a/packageurl.go
+++ b/packageurl.go
@@ -586,8 +586,7 @@ func typeAdjustName(purlType, name string, qualifiers Qualifiers) string {
 		TypeComposer,
 		TypeDebian,
 		TypeGithub,
-		TypeGolang,
-		TypeNPM:
+		TypeGolang:
 		return strings.ToLower(name)
 	case TypePyPi:
 		return strings.ToLower(strings.ReplaceAll(name, "_", "-"))

--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -515,12 +515,12 @@ func TestNormalize(t *testing.T) {
 	}, {
 		name: "known type namespace adjustments",
 		input: packageurl.PackageURL{
-			Type:      "npm",
+			Type:      "apk",
 			Namespace: "NaMeSpAcE",
 			Name:      "pkg",
 		},
 		want: packageurl.PackageURL{
-			Type:       "npm",
+			Type:       "apk",
 			Namespace:  "namespace",
 			Name:       "pkg",
 			Qualifiers: packageurl.Qualifiers{},

--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -528,11 +528,11 @@ func TestNormalize(t *testing.T) {
 	}, {
 		name: "known type name adjustments",
 		input: packageurl.PackageURL{
-			Type: "npm",
+			Type: "alpm",
 			Name: "nAmE",
 		},
 		want: packageurl.PackageURL{
-			Type:       "npm",
+			Type:       "alpm",
 			Name:       "name",
 			Qualifiers: packageurl.Qualifiers{},
 		},


### PR DESCRIPTION
Package names on npm have not always been forced to lower case, it is only enforced for new packages (see https://docs.npmjs.com/cli/v10/configuring-npm/package-json).

There are a number of cases where there are two distinct packages that differ only in casing, such as (borrowing from https://github.com/package-url/packageurl-java/pull/38):

https://www.npmjs.com/package/Base64/v/1.0.0

https://www.npmjs.com/package/base64/v/1.0.0


Notably the Java implementation already does this (PR linked above), this discrepancy is certainly unfortunate.