### PR TITLE
Run tests using reference data from purl-spec

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,9 +14,8 @@ jobs:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Download test data
-        # TODO(@shibumi): Remove pinned version and reset to master, once the failing npm test-cases got fixed.
-        run: curl -L https://raw.githubusercontent.com/package-url/purl-spec/0dd92f26f8bb11956ffdf5e8acfcee71e8560407/test-suite-data.json -o testdata/test-suite-data.json
+        with:
+          submodules: true
       - name: Test go fmt
         run: test -z $(go fmt ./...)
       - name: Golangci-lint

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "testdata/purl-spec"]
+	path = testdata/purl-spec
+	url = https://github.com/package-url/purl-spec

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 test:
 	git submodule update --init
-	# git submodule update --remote
+	git submodule update --remote
 	go test -v -cover ./...
 
 fuzz:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .PHONY: test clean lint
 
 test:
-	curl -Ls https://raw.githubusercontent.com/package-url/purl-spec/master/test-suite-data.json -o testdata/test-suite-data.json
+	git submodule update --init
+	# git submodule update --remote
 	go test -v -cover ./...
 
 fuzz:


### PR DESCRIPTION
Adds test coverage using reference data provided by `purl-spec` https://github.com/aboutcode-org/purl-spec/tree/main/tests/types.
The test schema is available https://github.com/aboutcode-org/purl-spec/blob/main/schemas/purl-test.schema.json.

> [!NOTE]  
> Out of 481 reference tests, 85 are failing.

Related issue: https://github.com/aboutcode-org/purl-spec/issues/30