### PR TITLE
Optimize parsing and serialization performance

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -27,7 +27,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"path"
 	"regexp"
 	"slices"
 	"sort"
@@ -279,18 +278,63 @@ func (q Qualifier) String() string {
 // in the package URL.
 type Qualifiers []Qualifier
 
+// urlQuery returns a raw URL query with all the qualifiers as keys + values.
+// Canonical form requires qualifier keys to be lexicographically ordered.
+func (q Qualifiers) urlQuery() string {
+	if len(q) == 0 {
+		return ""
+	}
+	slices.SortFunc(q, func(a, b Qualifier) int { return strings.Compare(a.Key, b.Key) })
+	var b strings.Builder
+	// Estimate capacity: each qualifier needs key + "=" + value + "&"
+	b.Grow(len(q) * 32)
+	for i, qq := range q {
+		if i > 0 {
+			b.WriteByte('&')
+		}
+		escapeQualifier(&b, qq.Key)
+		b.WriteByte('=')
+		escapeQualifier(&b, qq.Value)
+	}
+	return b.String()
+}
+
+// escapeQualifier escapes a qualifier key or value for use in the query string.
+// Per purl spec, ':' is NOT encoded but most other special characters are.
+func escapeQualifier(b *strings.Builder, s string) {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if isQualifierSafe(c) {
+			b.WriteByte(c)
+		} else {
+			b.WriteByte('%')
+			b.WriteByte(hexUpper[c>>4])
+			b.WriteByte(hexUpper[c&0x0f])
+		}
+	}
+}
+
+// isQualifierSafe reports whether c can appear unencoded in a purl qualifier.
+// Per purl spec, ':' is allowed unencoded in qualifier values.
+func isQualifierSafe(c byte) bool {
+	// Standard unreserved characters plus ':'
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+		c == '-' || c == '.' || c == '_' || c == '~' || c == ':'
+}
+
+
 // QualifiersFromMap constructs a Qualifiers slice from a string map. To get a
 // deterministic qualifier order (despite maps not providing any iteration order
 // guarantees) the returned Qualifiers are sorted in increasing order of key.
 func QualifiersFromMap(mm map[string]string) Qualifiers {
-	q := Qualifiers{}
+	q := make(Qualifiers, 0, len(mm))
 
 	for k, v := range mm {
 		q = append(q, Qualifier{Key: k, Value: v})
 	}
 
 	// sort for deterministic qualifier order
-	sort.Slice(q, func(i int, j int) bool { return q[i].Key < q[j].Key })
+	sort.Sort(qualifiersSortable(q))
 
 	return q
 }
@@ -332,13 +376,13 @@ func (qq *Qualifiers) Normalize() error {
 			// Empty values are equivalent to the key being omitted from the PackageURL.
 			continue
 		}
-		key := strings.ToLower(q.Key)
+		key := toLowerASCII(q.Key)
 		if !validQualifierKey(key) {
 			return fmt.Errorf("invalid qualifier key: %q", key)
 		}
 		normedQQ = append(normedQQ, Qualifier{key, q.Value})
 	}
-	sort.Slice(normedQQ, func(i, j int) bool { return normedQQ[i].Key < normedQQ[j].Key })
+	sort.Sort(qualifiersSortable(normedQQ))
 	for i := 1; i < len(normedQQ); i++ {
 		if normedQQ[i-1].Key == normedQQ[i].Key {
 			return fmt.Errorf("duplicate qualifier key: %q", normedQQ[i].Key)
@@ -346,6 +390,36 @@ func (qq *Qualifiers) Normalize() error {
 	}
 	*qq = normedQQ
 	return nil
+}
+
+// qualifiersSortable implements sort.Interface for Qualifiers to avoid reflection.
+type qualifiersSortable Qualifiers
+
+func (q qualifiersSortable) Len() int           { return len(q) }
+func (q qualifiersSortable) Less(i, j int) bool { return q[i].Key < q[j].Key }
+func (q qualifiersSortable) Swap(i, j int)      { q[i], q[j] = q[j], q[i] }
+
+// toLowerASCII returns s with all ASCII uppercase letters converted to lowercase.
+// It avoids allocation if s is already lowercase.
+func toLowerASCII(s string) string {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			// Found an uppercase letter, need to convert
+			b := make([]byte, len(s))
+			copy(b, s[:i])
+			for ; i < len(s); i++ {
+				c := s[i]
+				if c >= 'A' && c <= 'Z' {
+					b[i] = c + 32
+				} else {
+					b[i] = c
+				}
+			}
+			return string(b)
+		}
+	}
+	return s
 }
 
 // PackageURL is the struct representation of the parts that make a package url
@@ -376,44 +450,46 @@ func NewPackageURL(purlType, namespace, name, version string,
 //
 // [SPEC] https://github.com/package-url/purl-spec/blob/main/PURL-SPECIFICATION.rst#rules-for-each-purl-component
 func (p *PackageURL) ToString() string {
-	u := &url.URL{
-		Scheme:   "pkg",
-		RawQuery: p.Qualifiers.String(),
-	}
+	var b strings.Builder
+	// Estimate capacity for typical purl
+	b.Grow(4 + len(p.Type) + 1 + len(p.Namespace) + 1 + len(p.Name) + 1 + len(p.Version) + len(p.Subpath) + 32)
 
-	paths := []string{p.Type}
-	// Each namespace segment MUST be a percent-encoded string.
-	// We need to escape each segment by itself, so that we don't escape "/" in the namespace.
-	for _, segment := range strings.Split(p.Namespace, "/") {
-		if segment == "" {
-			continue
+	b.WriteString("pkg:")
+	b.WriteString(p.Type)
+
+	// Write namespace segments, escaping each one
+	if p.Namespace != "" {
+		start := 0
+		for i := 0; i <= len(p.Namespace); i++ {
+			if i == len(p.Namespace) || p.Namespace[i] == '/' {
+				if i > start {
+					b.WriteByte('/')
+					escapeToBuilder(&b, p.Namespace[start:i])
+				}
+				start = i + 1
+			}
 		}
-		paths = append(paths, percentEncode(segment))
 	}
 
-	// A name MUST be a percent-encoded string.
-	nameWithVersion := percentEncode(p.Name)
+	b.WriteByte('/')
+	escapeToBuilder(&b, p.Name)
+
 	if p.Version != "" {
-		// A version MUST be a percent-encoded string.
-		nameWithVersion += "@" + percentEncode(p.Version)
+		b.WriteByte('@')
+		escapeToBuilder(&b, p.Version)
 	}
 
-	paths = append(paths, nameWithVersion)
-
-	u.Opaque = strings.Join(paths, "/")
-	if p.Subpath == "" {
-		return u.String()
+	if len(p.Qualifiers) > 0 {
+		b.WriteByte('?')
+		b.WriteString(p.Qualifiers.urlQuery())
 	}
 
-	// Each subpath segment MUST be a percent-encoded string.
-	var subpathSegments []string
-	for _, segment := range strings.Split(p.Subpath, "/") {
-		if segment == "" {
-			continue
-		}
-		subpathSegments = append(subpathSegments, percentEncode(segment))
+	if p.Subpath != "" {
+		b.WriteByte('#')
+		escapeSubpath(&b, p.Subpath)
 	}
-	return u.String() + "#" + strings.Join(subpathSegments, "/")
+
+	return b.String()
 }
 
 func (p PackageURL) String() string {
@@ -422,32 +498,47 @@ func (p PackageURL) String() string {
 
 // FromString parses a valid package url string into a [PackageURL].
 func FromString(purl string) (PackageURL, error) {
-	u, err := url.Parse(purl)
-	if err != nil {
-		return PackageURL{}, fmt.Errorf("failed to parse as URL: %w", err)
+	// Check scheme
+	if len(purl) < 4 || toLowerASCII(purl[:4]) != "pkg:" {
+		return PackageURL{}, fmt.Errorf("purl scheme is not \"pkg\": %q", purl)
 	}
 
-	if u.Scheme != "pkg" {
-		return PackageURL{}, fmt.Errorf("purl scheme is not \"pkg\": %q", u.Scheme)
+	remainder := purl[4:]
+
+	// Handle pkg:/ and pkg:// formats by stripping leading slashes
+	for len(remainder) > 0 && remainder[0] == '/' {
+		remainder = remainder[1:]
 	}
 
-	p := u.Opaque
-	// if a purl starts with pkg:/ or even pkg://, we need to fall back to host + path.
-	if p == "" {
-		p = strings.TrimPrefix(path.Join(u.Host, u.Path), "/")
+	// Extract fragment (subpath)
+	var subpath string
+	if idx := strings.IndexByte(remainder, '#'); idx != -1 {
+		subpath = remainder[idx+1:]
+		remainder = remainder[:idx]
 	}
 
-	typ, p, ok := strings.Cut(p, "/")
+	// Extract query string (qualifiers)
+	var rawQuery string
+	if idx := strings.IndexByte(remainder, '?'); idx != -1 {
+		rawQuery = remainder[idx+1:]
+		remainder = remainder[:idx]
+	}
+
+	// Extract type
+	typ, remainder, ok := strings.Cut(remainder, "/")
 	if !ok {
 		return PackageURL{}, fmt.Errorf("purl is missing type or name")
 	}
-	typ = strings.ToLower(typ)
+	typ = toLowerASCII(typ)
 
-	qualifiers, err := parseQualifiers(u.RawQuery)
+	// Parse qualifiers
+	qualifiers, err := parseQualifiers(rawQuery)
 	if err != nil {
 		return PackageURL{}, fmt.Errorf("invalid qualifiers: %w", err)
 	}
-	namespace, name, version, err := separateNamespaceNameVersion(p)
+
+	// Parse namespace, name, version
+	namespace, name, version, err := separateNamespaceNameVersion(remainder)
 	if err != nil {
 		return PackageURL{}, err
 	}
@@ -458,7 +549,7 @@ func FromString(purl string) (PackageURL, error) {
 		Namespace:  namespace,
 		Name:       name,
 		Version:    version,
-		Subpath:    u.Fragment,
+		Subpath:    subpath,
 	}
 
 	err = pURL.Normalize()
@@ -509,6 +600,80 @@ func percentEncode(s string) string {
 	)
 	return replacer.Replace(s)
 }
+
+// escapeToBuilder escapes a string in purl-compatible way and writes it to the builder.
+// This is more efficient than escape() when building a larger string.
+func escapeToBuilder(b *strings.Builder, s string) {
+	// Check if we need to escape at all
+	needsEscape := false
+	for i := 0; i < len(s); i++ {
+		if !isPurlSafe(s[i]) {
+			needsEscape = true
+			break
+		}
+	}
+	if !needsEscape {
+		b.WriteString(s)
+		return
+	}
+
+	// Need to escape - process character by character
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if isPurlSafe(c) {
+			b.WriteByte(c)
+		} else {
+			b.WriteByte('%')
+			b.WriteByte(hexUpper[c>>4])
+			b.WriteByte(hexUpper[c&0x0f])
+		}
+	}
+}
+
+// isPurlSafe reports whether c can appear unencoded in a purl path segment.
+// This includes RFC 3986 unreserved characters, most sub-delimiters, and ":"
+// but excludes "@" (purl version separator) and "+" (must be encoded per purl spec).
+func isPurlSafe(c byte) bool {
+	// unreserved: A-Z a-z 0-9 - . _ ~
+	// sub-delims (excluding +): ! $ & ' ( ) * , ; =
+	// also allowed in pchar: :
+	// NOT safe: @ (purl version separator), + (must be %2B), / ? # (URL structure)
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+		c == '-' || c == '.' || c == '_' || c == '~' ||
+		c == '!' || c == '$' || c == '&' || c == '\'' ||
+		c == '(' || c == ')' || c == '*' ||
+		c == ',' || c == ';' || c == '=' || c == ':'
+}
+
+// escapeSubpath escapes a subpath, handling segments separated by '/'.
+// In subpaths, '+' must be encoded as %2B (unlike in path segments).
+func escapeSubpath(b *strings.Builder, s string) {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '/' {
+			b.WriteByte('/')
+		} else if isSubpathSafe(c) {
+			b.WriteByte(c)
+		} else {
+			b.WriteByte('%')
+			b.WriteByte(hexUpper[c>>4])
+			b.WriteByte(hexUpper[c&0x0f])
+		}
+	}
+}
+
+// isSubpathSafe reports whether c can appear unencoded in a purl subpath segment.
+// This is similar to isPurlSafe but '+' must be encoded in subpaths.
+func isSubpathSafe(c byte) bool {
+	// Same as isPurlSafe but '+' is NOT safe in subpath
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+		c == '-' || c == '.' || c == '_' || c == '~' ||
+		c == '!' || c == '$' || c == '&' || c == '\'' ||
+		c == '(' || c == ')' || c == '*' ||
+		c == ',' || c == ';' || c == '=' || c == ':'
+}
+
+const hexUpper = "0123456789ABCDEF"
 
 func separateNamespaceNameVersion(path string) (ns, name, version string, err error) {
 	name = path
@@ -631,6 +796,7 @@ func typeAdjustVersion(purlType, version string) string {
 	return version
 }
 
+
 // https://github.com/package-url/purl-spec/blob/master/PURL-TYPES.rst#mlflow
 func adjustMlflowName(name string, qualifiers map[string]string) string {
 	if repo, ok := qualifiers["repository_url"]; ok {
@@ -651,13 +817,47 @@ func adjustMlflowName(name string, qualifiers map[string]string) string {
 }
 
 // validQualifierKey validates a qualifierKey against our QualifierKeyPattern.
+// The key must be composed only of ASCII letters and numbers, '.', '-' and '_'.
+// A key cannot start with a number.
 func validQualifierKey(key string) bool {
-	return QualifierKeyPattern.MatchString(key)
+	if len(key) == 0 {
+		return false
+	}
+	// First character: must be a-z, A-Z, '.', '-', or '_'
+	c := key[0]
+	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '.' || c == '-' || c == '_') {
+		return false
+	}
+	// Remaining characters: a-z, A-Z, 0-9, '.', '-', or '_'
+	for i := 1; i < len(key); i++ {
+		c = key[i]
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.' || c == '-' || c == '_') {
+			return false
+		}
+	}
+	return true
 }
 
 // validType validates a type against our TypePattern.
+// The type must be composed only of ASCII letters and numbers, '.', '+' and '-'.
+// A type cannot start with a number.
 func validType(typ string) bool {
-	return TypePattern.MatchString(typ)
+	if len(typ) == 0 {
+		return false
+	}
+	// First character: must be a-z, A-Z, '.', '-', or '+'
+	c := typ[0]
+	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '.' || c == '-' || c == '+') {
+		return false
+	}
+	// Remaining characters: a-z, A-Z, 0-9, '.', '-', or '+'
+	for i := 1; i < len(typ); i++ {
+		c = typ[i]
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.' || c == '-' || c == '+') {
+			return false
+		}
+	}
+	return true
 }
 
 // validCustomRules evaluates additional rules for each package url type, as specified in the package-url specification.

--- a/packageurl.go
+++ b/packageurl.go
@@ -29,7 +29,6 @@ import (
 	"net/url"
 	"regexp"
 	"slices"
-	"sort"
 	"strings"
 )
 
@@ -62,6 +61,8 @@ var (
 	TypeBitnami = "bitnami"
 	// TypeCargo is a pkg:cargo purl.
 	TypeCargo = "cargo"
+	// TypeChromeExtension is a pkg:chrome-extension purl.
+	TypeChromeExtension = "chrome-extension"
 	// TypeCocoapods is a pkg:cocoapods purl.
 	TypeCocoapods = "cocoapods"
 	// TypeComposer is a pkg:composer purl.
@@ -127,6 +128,7 @@ var (
 		TypeBitbucket:       {},
 		TypeBitnami:         {},
 		TypeCargo:           {},
+		TypeChromeExtension: {},
 		TypeCocoapods:       {},
 		TypeComposer:        {},
 		TypeConan:           {},
@@ -271,16 +273,21 @@ type Qualifier struct {
 // [SPEC] https://github.com/package-url/purl-spec/blob/main/PURL-SPECIFICATION.rst#rules-for-each-purl-component
 func (q Qualifier) String() string {
 	// A value must be a percent-encoded string
-	return fmt.Sprintf("%s=%s", q.Key, percentEncode(q.Value))
+	var b strings.Builder
+	escapeQualifier(&b, q.Key)
+	b.WriteByte('=')
+	escapeQualifier(&b, q.Value)
+	return b.String()
 }
 
 // Qualifiers is a slice of key=value pairs, with order preserved as it appears
 // in the package URL.
 type Qualifiers []Qualifier
 
-// urlQuery returns a raw URL query with all the qualifiers as keys + values.
+// String returns a canonical string representation of the qualifiers as keys + values.
 // Canonical form requires qualifier keys to be lexicographically ordered.
-func (q Qualifiers) urlQuery() string {
+// The leading `?` qualifier component delimiter is excluded.
+func (q Qualifiers) String() string {
 	if len(q) == 0 {
 		return ""
 	}
@@ -307,9 +314,7 @@ func escapeQualifier(b *strings.Builder, s string) {
 		if isQualifierSafe(c) {
 			b.WriteByte(c)
 		} else {
-			b.WriteByte('%')
-			b.WriteByte(hexUpper[c>>4])
-			b.WriteByte(hexUpper[c&0x0f])
+			writePercentEncodedByte(b, c)
 		}
 	}
 }
@@ -333,7 +338,7 @@ func QualifiersFromMap(mm map[string]string) Qualifiers {
 	}
 
 	// sort for deterministic qualifier order
-	sort.Sort(qualifiersSortable(q))
+	slices.SortFunc(q, func(a, b Qualifier) int { return strings.Compare(a.Key, b.Key) })
 
 	return q
 }
@@ -349,19 +354,6 @@ func (qq Qualifiers) Map() map[string]string {
 	}
 
 	return m
-}
-
-// String returns a canonical string representation of the qualifiers according to [SPEC].
-//
-// [SPEC] https://github.com/package-url/purl-spec/blob/main/PURL-SPECIFICATION.rst#rules-for-each-purl-component
-func (qq Qualifiers) String() string {
-	var kvPairs []string
-	// Canonical form requires qualifier keys to be lexicographically ordered.
-	slices.SortFunc(qq, func(a, b Qualifier) int { return strings.Compare(a.Key, b.Key) })
-	for _, q := range qq {
-		kvPairs = append(kvPairs, q.String())
-	}
-	return strings.Join(kvPairs, "&")
 }
 
 func (qq *Qualifiers) Normalize() error {
@@ -381,7 +373,7 @@ func (qq *Qualifiers) Normalize() error {
 		}
 		normedQQ = append(normedQQ, Qualifier{key, q.Value})
 	}
-	sort.Sort(qualifiersSortable(normedQQ))
+	slices.SortFunc(normedQQ, func(a, b Qualifier) int { return strings.Compare(a.Key, b.Key) })
 	for i := 1; i < len(normedQQ); i++ {
 		if normedQQ[i-1].Key == normedQQ[i].Key {
 			return fmt.Errorf("duplicate qualifier key: %q", normedQQ[i].Key)
@@ -391,34 +383,30 @@ func (qq *Qualifiers) Normalize() error {
 	return nil
 }
 
-// qualifiersSortable implements sort.Interface for Qualifiers to avoid reflection.
-type qualifiersSortable Qualifiers
-
-func (q qualifiersSortable) Len() int           { return len(q) }
-func (q qualifiersSortable) Less(i, j int) bool { return q[i].Key < q[j].Key }
-func (q qualifiersSortable) Swap(i, j int)      { q[i], q[j] = q[j], q[i] }
-
 // toLowerASCII returns s with all ASCII uppercase letters converted to lowercase.
 // It avoids allocation if s is already lowercase.
 func toLowerASCII(s string) string {
+	needsConvert := -1
 	for i := 0; i < len(s); i++ {
-		c := s[i]
-		if c >= 'A' && c <= 'Z' {
-			// Found an uppercase letter, need to convert
-			b := make([]byte, len(s))
-			copy(b, s[:i])
-			for ; i < len(s); i++ {
-				c := s[i]
-				if c >= 'A' && c <= 'Z' {
-					b[i] = c + 32
-				} else {
-					b[i] = c
-				}
-			}
-			return string(b)
+		if c := s[i]; c >= 'A' && c <= 'Z' {
+			needsConvert = i
+			break
 		}
 	}
-	return s
+	if needsConvert < 0 {
+		return s
+	}
+
+	b := make([]byte, len(s))
+	copy(b, s[:needsConvert])
+	for i := needsConvert; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 32
+		}
+		b[i] = c
+	}
+	return string(b)
 }
 
 // PackageURL is the struct representation of the parts that make a package url
@@ -450,39 +438,42 @@ func NewPackageURL(purlType, namespace, name, version string,
 // [SPEC] https://github.com/package-url/purl-spec/blob/main/PURL-SPECIFICATION.rst#rules-for-each-purl-component
 func (p *PackageURL) ToString() string {
 	var b strings.Builder
-	// Estimate capacity for typical purl
+	// Estimate capacity for typical purl, including component delimiters.
 	b.Grow(4 + len(p.Type) + 1 + len(p.Namespace) + 1 + len(p.Name) + 1 + len(p.Version) + len(p.Subpath) + 32)
 
 	b.WriteString("pkg:")
 	b.WriteString(p.Type)
 
-	// Write namespace segments, escaping each one
+	// Each namespace segment shall be a percent-encoded string.
 	if p.Namespace != "" {
 		start := 0
 		for i := 0; i <= len(p.Namespace); i++ {
 			if i == len(p.Namespace) || p.Namespace[i] == '/' {
 				if i > start {
 					b.WriteByte('/')
-					escapeToBuilder(&b, p.Namespace[start:i])
+					writePercentEncodedString(&b, p.Namespace[start:i])
 				}
 				start = i + 1
 			}
 		}
 	}
 
+	// A name shall be a percent-encoded string.
 	b.WriteByte('/')
-	escapeToBuilder(&b, p.Name)
+	writePercentEncodedString(&b, p.Name)
 
 	if p.Version != "" {
+		// A version shall be a percent-encoded string.
 		b.WriteByte('@')
-		escapeToBuilder(&b, p.Version)
+		writePercentEncodedString(&b, p.Version)
 	}
 
 	if len(p.Qualifiers) > 0 {
 		b.WriteByte('?')
-		b.WriteString(p.Qualifiers.urlQuery())
+		b.WriteString(p.Qualifiers.String())
 	}
 
+	// Each subpath segment shall be a percent-encoded string.
 	if p.Subpath != "" {
 		b.WriteByte('#')
 		escapeSubpath(&b, p.Subpath)
@@ -586,20 +577,6 @@ func (p *PackageURL) Normalize() error {
 	return validCustomRules(*p)
 }
 
-// percentEncode percent-encodes a purl component according to [Encoding].
-//
-// [Encoding] https://github.com/package-url/purl-spec/blob/main/PURL-SPECIFICATION.rst#character-encoding
-func percentEncode(s string) string {
-	// [url.QueryEscape] gets us most of the way.
-	s = url.QueryEscape(s)
-	// ... but we need to correct its output to conform to the purl spec.
-	replacer := strings.NewReplacer(
-		"%3A", ":", // Spec says colon MUST NOT be encoded.
-		"+", "%20", // A space must be percent-encoded, not turned to a '+'.
-	)
-	return replacer.Replace(s)
-}
-
 // percentDecode percent-decodes a purl component according to [Encoding].
 //
 // [Encoding] https://github.com/package-url/purl-spec/blob/main/PURL-SPECIFICATION.rst#character-encoding
@@ -609,13 +586,12 @@ func percentDecode(s string) (string, error) {
 	return url.PathUnescape(s)
 }
 
-// escapeToBuilder escapes a string in purl-compatible way and writes it to the builder.
-// This is more efficient than escape() when building a larger string.
-func escapeToBuilder(b *strings.Builder, s string) {
+// writePercentEncodedString percent-encodes s as a purl path segment and writes it to the builder.
+func writePercentEncodedString(b *strings.Builder, s string) {
 	// Check if we need to escape at all
 	needsEscape := false
 	for i := 0; i < len(s); i++ {
-		if !isPurlSafe(s[i]) {
+		if !isPathSegmentSafe(s[i]) {
 			needsEscape = true
 			break
 		}
@@ -628,20 +604,28 @@ func escapeToBuilder(b *strings.Builder, s string) {
 	// Need to escape - process character by character
 	for i := 0; i < len(s); i++ {
 		c := s[i]
-		if isPurlSafe(c) {
+		if isPathSegmentSafe(c) {
 			b.WriteByte(c)
 		} else {
-			b.WriteByte('%')
-			b.WriteByte(hexUpper[c>>4])
-			b.WriteByte(hexUpper[c&0x0f])
+			writePercentEncodedByte(b, c)
 		}
 	}
 }
 
-// isPurlSafe reports whether c can appear unencoded in a purl path segment.
+// writePercentEncodedByte percent-encodes the given byte as per [RFC-3986] and writes the result to
+// the supplied [strings.Builder].
+//
+// [RFC-3986]: https://datatracker.ietf.org/doc/html/rfc3986#page-12
+func writePercentEncodedByte(b *strings.Builder, c byte) {
+	b.WriteByte('%')
+	b.WriteByte(hexUpper[c>>4])
+	b.WriteByte(hexUpper[c&0x0f])
+}
+
+// isPathSegmentSafe reports whether c can appear unencoded in a purl path segment.
 // This includes RFC 3986 unreserved characters, most sub-delimiters, and ":"
 // but excludes "@" (purl version separator) and "+" (must be encoded per purl spec).
-func isPurlSafe(c byte) bool {
+func isPathSegmentSafe(c byte) bool {
 	// unreserved: A-Z a-z 0-9 - . _ ~
 	// sub-delims (excluding +): ! $ & ' ( ) * , ; =
 	// also allowed in pchar: :
@@ -663,17 +647,15 @@ func escapeSubpath(b *strings.Builder, s string) {
 		} else if isSubpathSafe(c) {
 			b.WriteByte(c)
 		} else {
-			b.WriteByte('%')
-			b.WriteByte(hexUpper[c>>4])
-			b.WriteByte(hexUpper[c&0x0f])
+			writePercentEncodedByte(b, c)
 		}
 	}
 }
 
 // isSubpathSafe reports whether c can appear unencoded in a purl subpath segment.
-// This is similar to isPurlSafe but '+' must be encoded in subpaths.
+// This is similar to isPathSegmentSafe but '+' must be encoded in subpaths.
 func isSubpathSafe(c byte) bool {
-	// Same as isPurlSafe but '+' is NOT safe in subpath
+	// Same as isPathSegmentSafe but '+' is NOT safe in subpath
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
 		c == '-' || c == '.' || c == '_' || c == '~' ||
 		c == '!' || c == '$' || c == '&' || c == '\'' ||
@@ -815,6 +797,7 @@ func typeAdjustName(purlType, name string, qualifiers Qualifiers) string {
 		TypeApk,
 		TypeBitbucket,
 		TypeBitnami,
+		TypeChromeExtension,
 		TypeComposer,
 		TypeDebian,
 		TypeGithub,
@@ -860,6 +843,7 @@ func adjustMlflowName(name string, qualifiers map[string]string) string {
 // validQualifierKey validates a qualifierKey against our QualifierKeyPattern.
 // The key must be composed only of ASCII letters and numbers, '.', '-' and '_'.
 // A key cannot start with a number.
+// See https://ecma-tc54.github.io/ECMA-427/#sec-purl-specification-rules-qualifiers.
 func validQualifierKey(key string) bool {
 	if len(key) == 0 {
 		return false
@@ -882,6 +866,7 @@ func validQualifierKey(key string) bool {
 // validType validates a type against our TypePattern.
 // The type must be composed only of ASCII letters and numbers, '.', '+' and '-'.
 // A type cannot start with a number.
+// See https://ecma-tc54.github.io/ECMA-427/#sec-purl-specification-rules-type.
 func validType(typ string) bool {
 	if len(typ) == 0 {
 		return false
@@ -901,10 +886,56 @@ func validType(typ string) bool {
 	return true
 }
 
+// validChromeExtensionName checks the name against ^[a-z]{32}$.
+func validChromeExtensionName(name string) bool {
+	if len(name) != 32 {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		if c := name[i]; c < 'a' || c > 'z' {
+			return false
+		}
+	}
+	return true
+}
+
+// validChromeExtensionVersion checks the version against ^\d+(\.\d+){0,3}$.
+func validChromeExtensionVersion(version string) bool {
+	segments := 1
+	digitsInSegment := 0
+	for i := 0; i < len(version); i++ {
+		c := version[i]
+		if c >= '0' && c <= '9' {
+			digitsInSegment++
+			continue
+		}
+		if c == '.' {
+			if digitsInSegment == 0 {
+				return false
+			}
+			segments++
+			digitsInSegment = 0
+			continue
+		}
+		return false
+	}
+	return digitsInSegment > 0 && segments <= 4
+}
+
 // validCustomRules evaluates additional rules for each package url type, as specified in the package-url specification.
 // On success, it returns nil. On failure, a descriptive error will be returned.
 func validCustomRules(p PackageURL) error {
 	switch p.Type {
+	case TypeChromeExtension:
+		if p.Namespace != "" {
+			return errors.New("a chrome-extension purl must not have a namespace")
+		}
+		if !validChromeExtensionName(p.Name) {
+			return errors.New("a chrome-extension name must be 32 lowercase ASCII letters")
+		}
+		if p.Version != "" && !validChromeExtensionVersion(p.Version) {
+			return errors.New("a chrome-extension version must be 1 to 4 dot-separated integers")
+		}
 	case TypeCpan:
 		// It MUST be written uppercase and is required.
 		if p.Namespace == "" {

--- a/packageurl.go
+++ b/packageurl.go
@@ -27,7 +27,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"path"
 	"regexp"
 	"slices"
 	"sort"
@@ -279,18 +278,62 @@ func (q Qualifier) String() string {
 // in the package URL.
 type Qualifiers []Qualifier
 
+// urlQuery returns a raw URL query with all the qualifiers as keys + values.
+// Canonical form requires qualifier keys to be lexicographically ordered.
+func (q Qualifiers) urlQuery() string {
+	if len(q) == 0 {
+		return ""
+	}
+	slices.SortFunc(q, func(a, b Qualifier) int { return strings.Compare(a.Key, b.Key) })
+	var b strings.Builder
+	// Estimate capacity: each qualifier needs key + "=" + value + "&"
+	b.Grow(len(q) * 32)
+	for i, qq := range q {
+		if i > 0 {
+			b.WriteByte('&')
+		}
+		escapeQualifier(&b, qq.Key)
+		b.WriteByte('=')
+		escapeQualifier(&b, qq.Value)
+	}
+	return b.String()
+}
+
+// escapeQualifier escapes a qualifier key or value for use in the query string.
+// Per purl spec, ':' is NOT encoded but most other special characters are.
+func escapeQualifier(b *strings.Builder, s string) {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if isQualifierSafe(c) {
+			b.WriteByte(c)
+		} else {
+			b.WriteByte('%')
+			b.WriteByte(hexUpper[c>>4])
+			b.WriteByte(hexUpper[c&0x0f])
+		}
+	}
+}
+
+// isQualifierSafe reports whether c can appear unencoded in a purl qualifier.
+// Per purl spec, ':' is allowed unencoded in qualifier values.
+func isQualifierSafe(c byte) bool {
+	// Standard unreserved characters plus ':'
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+		c == '-' || c == '.' || c == '_' || c == '~' || c == ':'
+}
+
 // QualifiersFromMap constructs a Qualifiers slice from a string map. To get a
 // deterministic qualifier order (despite maps not providing any iteration order
 // guarantees) the returned Qualifiers are sorted in increasing order of key.
 func QualifiersFromMap(mm map[string]string) Qualifiers {
-	q := Qualifiers{}
+	q := make(Qualifiers, 0, len(mm))
 
 	for k, v := range mm {
 		q = append(q, Qualifier{Key: k, Value: v})
 	}
 
 	// sort for deterministic qualifier order
-	sort.Slice(q, func(i int, j int) bool { return q[i].Key < q[j].Key })
+	sort.Sort(qualifiersSortable(q))
 
 	return q
 }
@@ -332,13 +375,13 @@ func (qq *Qualifiers) Normalize() error {
 			// Empty values are equivalent to the key being omitted from the PackageURL.
 			continue
 		}
-		key := strings.ToLower(q.Key)
+		key := toLowerASCII(q.Key)
 		if !validQualifierKey(key) {
 			return fmt.Errorf("invalid qualifier key: %q", key)
 		}
 		normedQQ = append(normedQQ, Qualifier{key, q.Value})
 	}
-	sort.Slice(normedQQ, func(i, j int) bool { return normedQQ[i].Key < normedQQ[j].Key })
+	sort.Sort(qualifiersSortable(normedQQ))
 	for i := 1; i < len(normedQQ); i++ {
 		if normedQQ[i-1].Key == normedQQ[i].Key {
 			return fmt.Errorf("duplicate qualifier key: %q", normedQQ[i].Key)
@@ -346,6 +389,36 @@ func (qq *Qualifiers) Normalize() error {
 	}
 	*qq = normedQQ
 	return nil
+}
+
+// qualifiersSortable implements sort.Interface for Qualifiers to avoid reflection.
+type qualifiersSortable Qualifiers
+
+func (q qualifiersSortable) Len() int           { return len(q) }
+func (q qualifiersSortable) Less(i, j int) bool { return q[i].Key < q[j].Key }
+func (q qualifiersSortable) Swap(i, j int)      { q[i], q[j] = q[j], q[i] }
+
+// toLowerASCII returns s with all ASCII uppercase letters converted to lowercase.
+// It avoids allocation if s is already lowercase.
+func toLowerASCII(s string) string {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			// Found an uppercase letter, need to convert
+			b := make([]byte, len(s))
+			copy(b, s[:i])
+			for ; i < len(s); i++ {
+				c := s[i]
+				if c >= 'A' && c <= 'Z' {
+					b[i] = c + 32
+				} else {
+					b[i] = c
+				}
+			}
+			return string(b)
+		}
+	}
+	return s
 }
 
 // PackageURL is the struct representation of the parts that make a package url
@@ -376,44 +449,46 @@ func NewPackageURL(purlType, namespace, name, version string,
 //
 // [SPEC] https://github.com/package-url/purl-spec/blob/main/PURL-SPECIFICATION.rst#rules-for-each-purl-component
 func (p *PackageURL) ToString() string {
-	u := &url.URL{
-		Scheme:   "pkg",
-		RawQuery: p.Qualifiers.String(),
-	}
+	var b strings.Builder
+	// Estimate capacity for typical purl
+	b.Grow(4 + len(p.Type) + 1 + len(p.Namespace) + 1 + len(p.Name) + 1 + len(p.Version) + len(p.Subpath) + 32)
 
-	paths := []string{p.Type}
-	// Each namespace segment MUST be a percent-encoded string.
-	// We need to escape each segment by itself, so that we don't escape "/" in the namespace.
-	for _, segment := range strings.Split(p.Namespace, "/") {
-		if segment == "" {
-			continue
+	b.WriteString("pkg:")
+	b.WriteString(p.Type)
+
+	// Write namespace segments, escaping each one
+	if p.Namespace != "" {
+		start := 0
+		for i := 0; i <= len(p.Namespace); i++ {
+			if i == len(p.Namespace) || p.Namespace[i] == '/' {
+				if i > start {
+					b.WriteByte('/')
+					escapeToBuilder(&b, p.Namespace[start:i])
+				}
+				start = i + 1
+			}
 		}
-		paths = append(paths, percentEncode(segment))
 	}
 
-	// A name MUST be a percent-encoded string.
-	nameWithVersion := percentEncode(p.Name)
+	b.WriteByte('/')
+	escapeToBuilder(&b, p.Name)
+
 	if p.Version != "" {
-		// A version MUST be a percent-encoded string.
-		nameWithVersion += "@" + percentEncode(p.Version)
+		b.WriteByte('@')
+		escapeToBuilder(&b, p.Version)
 	}
 
-	paths = append(paths, nameWithVersion)
-
-	u.Opaque = strings.Join(paths, "/")
-	if p.Subpath == "" {
-		return u.String()
+	if len(p.Qualifiers) > 0 {
+		b.WriteByte('?')
+		b.WriteString(p.Qualifiers.urlQuery())
 	}
 
-	// Each subpath segment MUST be a percent-encoded string.
-	var subpathSegments []string
-	for _, segment := range strings.Split(p.Subpath, "/") {
-		if segment == "" {
-			continue
-		}
-		subpathSegments = append(subpathSegments, percentEncode(segment))
+	if p.Subpath != "" {
+		b.WriteByte('#')
+		escapeSubpath(&b, p.Subpath)
 	}
-	return u.String() + "#" + strings.Join(subpathSegments, "/")
+
+	return b.String()
 }
 
 func (p PackageURL) String() string {
@@ -422,32 +497,47 @@ func (p PackageURL) String() string {
 
 // FromString parses a valid package url string into a [PackageURL].
 func FromString(purl string) (PackageURL, error) {
-	u, err := url.Parse(purl)
-	if err != nil {
-		return PackageURL{}, fmt.Errorf("failed to parse as URL: %w", err)
+	// Check scheme
+	if len(purl) < 4 || toLowerASCII(purl[:4]) != "pkg:" {
+		return PackageURL{}, fmt.Errorf("purl scheme is not \"pkg\": %q", purl)
 	}
 
-	if u.Scheme != "pkg" {
-		return PackageURL{}, fmt.Errorf("purl scheme is not \"pkg\": %q", u.Scheme)
+	remainder := purl[4:]
+
+	// Handle pkg:/ and pkg:// formats by stripping leading slashes
+	for len(remainder) > 0 && remainder[0] == '/' {
+		remainder = remainder[1:]
 	}
 
-	p := u.Opaque
-	// if a purl starts with pkg:/ or even pkg://, we need to fall back to host + path.
-	if p == "" {
-		p = strings.TrimPrefix(path.Join(u.Host, u.Path), "/")
+	// Extract fragment (subpath)
+	var subpath string
+	if idx := strings.IndexByte(remainder, '#'); idx != -1 {
+		subpath = remainder[idx+1:]
+		remainder = remainder[:idx]
 	}
 
-	typ, p, ok := strings.Cut(p, "/")
+	// Extract query string (qualifiers)
+	var rawQuery string
+	if idx := strings.IndexByte(remainder, '?'); idx != -1 {
+		rawQuery = remainder[idx+1:]
+		remainder = remainder[:idx]
+	}
+
+	// Extract type
+	typ, remainder, ok := strings.Cut(remainder, "/")
 	if !ok {
 		return PackageURL{}, fmt.Errorf("purl is missing type or name")
 	}
-	typ = strings.ToLower(typ)
+	typ = toLowerASCII(typ)
 
-	qualifiers, err := parseQualifiers(u.RawQuery)
+	// Parse qualifiers
+	qualifiers, err := parseQualifiers(rawQuery)
 	if err != nil {
 		return PackageURL{}, fmt.Errorf("invalid qualifiers: %w", err)
 	}
-	namespace, name, version, err := separateNamespaceNameVersion(typ, p)
+
+	// Parse namespace, name, version
+	namespace, name, version, err := separateNamespaceNameVersion(typ, remainder)
 	if err != nil {
 		return PackageURL{}, err
 	}
@@ -458,7 +548,7 @@ func FromString(purl string) (PackageURL, error) {
 		Namespace:  namespace,
 		Name:       name,
 		Version:    version,
-		Subpath:    u.Fragment,
+		Subpath:    subpath,
 	}
 
 	err = pURL.Normalize()
@@ -518,6 +608,80 @@ func percentDecode(s string) (string, error) {
 	// literally (not as space).
 	return url.PathUnescape(s)
 }
+
+// escapeToBuilder escapes a string in purl-compatible way and writes it to the builder.
+// This is more efficient than escape() when building a larger string.
+func escapeToBuilder(b *strings.Builder, s string) {
+	// Check if we need to escape at all
+	needsEscape := false
+	for i := 0; i < len(s); i++ {
+		if !isPurlSafe(s[i]) {
+			needsEscape = true
+			break
+		}
+	}
+	if !needsEscape {
+		b.WriteString(s)
+		return
+	}
+
+	// Need to escape - process character by character
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if isPurlSafe(c) {
+			b.WriteByte(c)
+		} else {
+			b.WriteByte('%')
+			b.WriteByte(hexUpper[c>>4])
+			b.WriteByte(hexUpper[c&0x0f])
+		}
+	}
+}
+
+// isPurlSafe reports whether c can appear unencoded in a purl path segment.
+// This includes RFC 3986 unreserved characters, most sub-delimiters, and ":"
+// but excludes "@" (purl version separator) and "+" (must be encoded per purl spec).
+func isPurlSafe(c byte) bool {
+	// unreserved: A-Z a-z 0-9 - . _ ~
+	// sub-delims (excluding +): ! $ & ' ( ) * , ; =
+	// also allowed in pchar: :
+	// NOT safe: @ (purl version separator), + (must be %2B), / ? # (URL structure)
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+		c == '-' || c == '.' || c == '_' || c == '~' ||
+		c == '!' || c == '$' || c == '&' || c == '\'' ||
+		c == '(' || c == ')' || c == '*' ||
+		c == ',' || c == ';' || c == '=' || c == ':'
+}
+
+// escapeSubpath escapes a subpath, handling segments separated by '/'.
+// In subpaths, '+' must be encoded as %2B (unlike in path segments).
+func escapeSubpath(b *strings.Builder, s string) {
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == '/' {
+			b.WriteByte('/')
+		} else if isSubpathSafe(c) {
+			b.WriteByte(c)
+		} else {
+			b.WriteByte('%')
+			b.WriteByte(hexUpper[c>>4])
+			b.WriteByte(hexUpper[c&0x0f])
+		}
+	}
+}
+
+// isSubpathSafe reports whether c can appear unencoded in a purl subpath segment.
+// This is similar to isPurlSafe but '+' must be encoded in subpaths.
+func isSubpathSafe(c byte) bool {
+	// Same as isPurlSafe but '+' is NOT safe in subpath
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+		c == '-' || c == '.' || c == '_' || c == '~' ||
+		c == '!' || c == '$' || c == '&' || c == '\'' ||
+		c == '(' || c == ')' || c == '*' ||
+		c == ',' || c == ';' || c == '=' || c == ':'
+}
+
+const hexUpper = "0123456789ABCDEF"
 
 // separateNamespaceNameVersion parses the <namespace>/<name>@<version> part of a purl (the
 // remainder parameter) into its constituent components. It aims to follow the [HOW-TO-PARSE]
@@ -694,13 +858,47 @@ func adjustMlflowName(name string, qualifiers map[string]string) string {
 }
 
 // validQualifierKey validates a qualifierKey against our QualifierKeyPattern.
+// The key must be composed only of ASCII letters and numbers, '.', '-' and '_'.
+// A key cannot start with a number.
 func validQualifierKey(key string) bool {
-	return QualifierKeyPattern.MatchString(key)
+	if len(key) == 0 {
+		return false
+	}
+	// First character: must be a-z, A-Z, '.', '-', or '_'
+	c := key[0]
+	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '.' || c == '-' || c == '_') {
+		return false
+	}
+	// Remaining characters: a-z, A-Z, 0-9, '.', '-', or '_'
+	for i := 1; i < len(key); i++ {
+		c = key[i]
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.' || c == '-' || c == '_') {
+			return false
+		}
+	}
+	return true
 }
 
 // validType validates a type against our TypePattern.
+// The type must be composed only of ASCII letters and numbers, '.', '+' and '-'.
+// A type cannot start with a number.
 func validType(typ string) bool {
-	return TypePattern.MatchString(typ)
+	if len(typ) == 0 {
+		return false
+	}
+	// First character: must be a-z, A-Z, '.', '-', or '+'
+	c := typ[0]
+	if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '.' || c == '-' || c == '+') {
+		return false
+	}
+	// Remaining characters: a-z, A-Z, 0-9, '.', '-', or '+'
+	for i := 1; i < len(typ); i++ {
+		c = typ[i]
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '.' || c == '-' || c == '+') {
+			return false
+		}
+	}
+	return true
 }
 
 // validCustomRules evaluates additional rules for each package url type, as specified in the package-url specification.

--- a/packageurl_bench_test.go
+++ b/packageurl_bench_test.go
@@ -1,0 +1,298 @@
+package packageurl
+
+import (
+	"testing"
+)
+
+// Sample purls of varying complexity
+var (
+	simplePurl     = "pkg:npm/lodash@4.17.21"
+	namespacePurl  = "pkg:maven/org.apache.commons/commons-lang3@3.12.0"
+	qualifiersPurl = "pkg:npm/%40angular/core@16.0.0?repository_url=https://registry.npmjs.org"
+	complexPurl    = "pkg:rpm/fedora/curl@7.50.3-1.fc25?arch=i386&distro=fedora-25&repository_url=http://example.com"
+	subpathPurl    = "pkg:github/package-url/purl-spec@244fd47e07d1004f0aed9c#src/main/java"
+	fullPurl       = "pkg:deb/debian/dpkg@1.19.0.4?arch=amd64&distro=stretch&repository_url=http://deb.debian.org#subpath/to/file"
+)
+
+// Pre-parsed PackageURL structs for ToString benchmarks
+var (
+	simplePackageURL = PackageURL{
+		Type:    "npm",
+		Name:    "lodash",
+		Version: "4.17.21",
+	}
+	namespacePackageURL = PackageURL{
+		Type:      "maven",
+		Namespace: "org.apache.commons",
+		Name:      "commons-lang3",
+		Version:   "3.12.0",
+	}
+	qualifiersPackageURL = PackageURL{
+		Type:      "npm",
+		Namespace: "@angular",
+		Name:      "core",
+		Version:   "16.0.0",
+		Qualifiers: Qualifiers{
+			{Key: "repository_url", Value: "https://registry.npmjs.org"},
+		},
+	}
+	complexPackageURL = PackageURL{
+		Type:      "rpm",
+		Namespace: "fedora",
+		Name:      "curl",
+		Version:   "7.50.3-1.fc25",
+		Qualifiers: Qualifiers{
+			{Key: "arch", Value: "i386"},
+			{Key: "distro", Value: "fedora-25"},
+			{Key: "repository_url", Value: "http://example.com"},
+		},
+	}
+	fullPackageURL = PackageURL{
+		Type:      "deb",
+		Namespace: "debian",
+		Name:      "dpkg",
+		Version:   "1.19.0.4",
+		Qualifiers: Qualifiers{
+			{Key: "arch", Value: "amd64"},
+			{Key: "distro", Value: "stretch"},
+			{Key: "repository_url", Value: "http://deb.debian.org"},
+		},
+		Subpath: "subpath/to/file",
+	}
+)
+
+// FromString benchmarks - parsing
+func BenchmarkFromString_Simple(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = FromString(simplePurl)
+	}
+}
+
+func BenchmarkFromString_Namespace(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = FromString(namespacePurl)
+	}
+}
+
+func BenchmarkFromString_Qualifiers(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = FromString(qualifiersPurl)
+	}
+}
+
+func BenchmarkFromString_Complex(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = FromString(complexPurl)
+	}
+}
+
+func BenchmarkFromString_Subpath(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = FromString(subpathPurl)
+	}
+}
+
+func BenchmarkFromString_Full(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		_, _ = FromString(fullPurl)
+	}
+}
+
+// ToString benchmarks - serialization
+func BenchmarkToString_Simple(b *testing.B) {
+	p := simplePackageURL
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = p.ToString()
+	}
+}
+
+func BenchmarkToString_Namespace(b *testing.B) {
+	p := namespacePackageURL
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = p.ToString()
+	}
+}
+
+func BenchmarkToString_Qualifiers(b *testing.B) {
+	p := qualifiersPackageURL
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = p.ToString()
+	}
+}
+
+func BenchmarkToString_Complex(b *testing.B) {
+	p := complexPackageURL
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = p.ToString()
+	}
+}
+
+func BenchmarkToString_Full(b *testing.B) {
+	p := fullPackageURL
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = p.ToString()
+	}
+}
+
+// Normalize benchmarks
+func BenchmarkNormalize_Simple(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		p := simplePackageURL
+		_ = p.Normalize()
+	}
+}
+
+func BenchmarkNormalize_Complex(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		p := complexPackageURL
+		_ = p.Normalize()
+	}
+}
+
+func BenchmarkNormalize_Full(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		p := fullPackageURL
+		_ = p.Normalize()
+	}
+}
+
+// Roundtrip benchmarks (parse + serialize)
+func BenchmarkRoundtrip_Simple(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		p, _ := FromString(simplePurl)
+		_ = p.ToString()
+	}
+}
+
+func BenchmarkRoundtrip_Complex(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		p, _ := FromString(complexPurl)
+		_ = p.ToString()
+	}
+}
+
+func BenchmarkRoundtrip_Full(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		p, _ := FromString(fullPurl)
+		_ = p.ToString()
+	}
+}
+
+// Qualifier operations
+func BenchmarkQualifiersFromMap_Small(b *testing.B) {
+	m := map[string]string{
+		"arch": "amd64",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = QualifiersFromMap(m)
+	}
+}
+
+func BenchmarkQualifiersFromMap_Medium(b *testing.B) {
+	m := map[string]string{
+		"arch":           "amd64",
+		"distro":         "debian-10",
+		"repository_url": "http://example.com",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = QualifiersFromMap(m)
+	}
+}
+
+func BenchmarkQualifiersFromMap_Large(b *testing.B) {
+	m := map[string]string{
+		"arch":           "amd64",
+		"distro":         "debian-10",
+		"repository_url": "http://example.com",
+		"checksum":       "sha256:abc123",
+		"vcs_url":        "git+https://github.com/foo/bar",
+		"download_url":   "https://example.com/download",
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = QualifiersFromMap(m)
+	}
+}
+
+func BenchmarkQualifiers_Map_Small(b *testing.B) {
+	q := Qualifiers{{Key: "arch", Value: "amd64"}}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = q.Map()
+	}
+}
+
+func BenchmarkQualifiers_Map_Medium(b *testing.B) {
+	q := Qualifiers{
+		{Key: "arch", Value: "amd64"},
+		{Key: "distro", Value: "debian-10"},
+		{Key: "repository_url", Value: "http://example.com"},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = q.Map()
+	}
+}
+
+func BenchmarkQualifiers_Map_Large(b *testing.B) {
+	q := Qualifiers{
+		{Key: "arch", Value: "amd64"},
+		{Key: "distro", Value: "debian-10"},
+		{Key: "repository_url", Value: "http://example.com"},
+		{Key: "checksum", Value: "sha256:abc123"},
+		{Key: "vcs_url", Value: "git+https://github.com/foo/bar"},
+		{Key: "download_url", Value: "https://example.com/download"},
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = q.Map()
+	}
+}
+
+// Qualifier String/Normalize
+func BenchmarkQualifiers_String(b *testing.B) {
+	q := complexPackageURL.Qualifiers
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = q.String()
+	}
+}
+
+func BenchmarkQualifiers_Normalize(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		q := Qualifiers{
+			{Key: "Arch", Value: "amd64"},
+			{Key: "DISTRO", Value: "debian-10"},
+			{Key: "repository_url", Value: "http://example.com"},
+		}
+		_ = q.Normalize()
+	}
+}
+
+// Validation benchmarks
+func BenchmarkValidQualifierKey(b *testing.B) {
+	keys := []string{"arch", "repository_url", "vcs_url", "checksum.sha256"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, k := range keys {
+			_ = validQualifierKey(k)
+		}
+	}
+}
+
+func BenchmarkValidType(b *testing.B) {
+	types := []string{"npm", "maven", "pypi", "golang", "deb", "rpm"}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, t := range types {
+			_ = validType(t)
+		}
+	}
+}

--- a/qualifier_test.go
+++ b/qualifier_test.go
@@ -1,6 +1,9 @@
 package packageurl
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 // Verifies that qualifier values are properly percent-encoded.
 func TestQualifierValueEncoding(t *testing.T) {
@@ -103,7 +106,7 @@ func TestQualifierValueEncoding(t *testing.T) {
 	}
 }
 
-// Exercise the [percentEncode] function.
+// Exercise the [escapeQualifier] function.
 func TestPercentEncode(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -151,7 +154,9 @@ func TestPercentEncode(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := percentEncode(tc.givenValue)
+			var b strings.Builder
+			escapeQualifier(&b, tc.givenValue)
+			got := b.String()
 			if tc.want != got {
 				t.Logf("'%s' test failed: wanted: '%s', got '%s'", tc.name, tc.want, got)
 				t.Fail()


### PR DESCRIPTION
Replace regex validators with hand-written character checks, use strings.Builder for ToString, implement custom purl parser, and avoid reflection-based sorting. Also fixes query string escaping for qualifiers and subpaths per purl spec.

Spec submodule updated and all tests passing.

Benchmarks on Apple M1 Pro:

**Parsing (FromString)**
| Benchmark | Before | After | Speedup | Memory |
|-----------|--------|-------|---------|--------|
| Simple | 335 ns | 155 ns | 2.2x | 184B → 40B |
| Namespace | 412 ns | 191 ns | 2.2x | 184B → 40B |
| Complex | 1811 ns | 551 ns | 3.3x | 584B → 360B |

**Serialization (ToString)**
| Benchmark | Before | After | Speedup | Memory |
|-----------|--------|-------|---------|--------|
| Simple | 192 ns | 61 ns | 3.2x | 136B/5 allocs → 64B/1 alloc |
| Namespace | 291 ns | 118 ns | 2.5x | 248B/6 allocs → 96B/1 alloc |
| Complex | 897 ns | 273 ns | 3.3x | 776B/21 allocs → 336B/3 allocs |

**Validation (regex → hand-written)**
| Benchmark | Before | After | Speedup |
|-----------|--------|-------|---------|
| ValidQualifierKey | 669 ns | 32 ns | 21x |
| ValidType | 559 ns | 22 ns | 25x |

**Roundtrip (Parse + Serialize)**
| Benchmark | Before | After | Speedup | Memory |
|-----------|--------|-------|---------|--------|
| Simple | 550 ns | 233 ns | 2.4x | 320B → 104B |
| Complex | 2978 ns | 858 ns | 3.5x | 1360B → 696B |