### PR TITLE
Remove required check of version field for CRAN and Swift

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -677,13 +677,6 @@ func validCustomRules(p PackageURL) error {
 		if p.Namespace == "" {
 			return errors.New("namespace is required")
 		}
-		if p.Version == "" {
-			return errors.New("version is required")
-		}
-	case TypeCran:
-		if p.Version == "" {
-			return errors.New("version is required")
-		}
 	}
 	return nil
 }


### PR DESCRIPTION
Currently the version for the Swift and CRAN ecosystems is validated as "required". If the version is missing for these ecosystems then validation fails.

According to https://github.com/package-url/purl-spec/blob/main/types/cran-definition.json and https://github.com/package-url/purl-spec/blob/main/types/swift-definition.json the "version" field is optional.

This change removes this check for these ecosystems.