### PR TITLE
Handle non-canonical input purls a bit more gracefully

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -447,7 +447,7 @@ func FromString(purl string) (PackageURL, error) {
 	if err != nil {
 		return PackageURL{}, fmt.Errorf("invalid qualifiers: %w", err)
 	}
-	namespace, name, version, err := separateNamespaceNameVersion(p)
+	namespace, name, version, err := separateNamespaceNameVersion(typ, p)
 	if err != nil {
 		return PackageURL{}, err
 	}
@@ -510,37 +510,84 @@ func percentEncode(s string) string {
 	return replacer.Replace(s)
 }
 
-func separateNamespaceNameVersion(path string) (ns, name, version string, err error) {
-	name = path
+// percentDecode percent-decodes a purl component according to [Encoding].
+//
+// [Encoding] https://github.com/package-url/purl-spec/blob/main/PURL-SPECIFICATION.rst#character-encoding
+func percentDecode(s string) (string, error) {
+	// Note: uses [url.PathUnescape] instead of [url.QueryUnescape] to treat '+' characters
+	// literally (not as space).
+	return url.PathUnescape(s)
+}
 
-	if namespaceSep := strings.LastIndex(name, "/"); namespaceSep != -1 {
-		ns, name = name[:namespaceSep], name[namespaceSep+1:]
-
-		ns, err = url.PathUnescape(ns)
-		if err != nil {
-			return "", "", "", fmt.Errorf("error unescaping namespace: %w", err)
-		}
+// separateNamespaceNameVersion parses the <namespace>/<name>@<version> part of a purl (the
+// remainder parameter) into its constituent components. It aims to follow the [HOW-TO-PARSE]
+// procedure.
+//
+// [HOW-TO-PARSE]: https://github.com/package-url/purl-spec/blob/main/docs/how-to-parse.md
+func separateNamespaceNameVersion(purlType string, remainder string) (ns, name, version string, err error) {
+	// NPM purls can have a namespace ("scope") that starts with an '@' character.
+	// For example, "pkg:npm/@babel/core".
+	// For any other purl type this indicates malformed purl input.
+	if purlType != TypeNPM && strings.HasPrefix(remainder, "@") {
+		return "", "", "", fmt.Errorf("purl is missing name")
 	}
 
-	if versionSep := strings.LastIndex(name, "@"); versionSep != -1 {
-		name, version = name[:versionSep], name[versionSep+1:]
-
-		version, err = url.PathUnescape(version)
+	// Split the remainder once from right on '@'.
+	// The left side is the remainder.
+	if strings.LastIndex(remainder, "@") > 0 {
+		remainder, version = rightmostSplit(remainder, "@")
+		// Percent-decode the right side. This is the version.
+		version, err = percentDecode(version)
 		if err != nil {
 			return "", "", "", fmt.Errorf("error unescaping version: %w", err)
 		}
 	}
 
-	name, err = url.PathUnescape(name)
+	// Split this once from right on '/'.
+	// The left side is the remainder.
+	remainder, name = rightmostSplit(remainder, "/")
+	// Percent-decode the right side. This is the name.
+	name, err = percentDecode(name)
 	if err != nil {
 		return "", "", "", fmt.Errorf("error unescaping name: %w", err)
 	}
+
+	// Split the remainder on '/'.
+	segments := strings.Split(remainder, "/")
+	nsSegments := []string{}
+	for _, segment := range segments {
+		// Discard any empty segment from that split.
+		if segment == "" {
+			continue
+		}
+		// Percent-decode each segment.
+		nsSegment, err := percentDecode(segment)
+		if err != nil {
+			return "", "", "", fmt.Errorf("error unescaping namespace: %w", err)
+		}
+		nsSegments = append(nsSegments, nsSegment)
+	}
+	// Join segments back with a '/'.
+	ns = strings.Join(nsSegments, "/")
 
 	if name == "" {
 		return "", "", "", fmt.Errorf("purl is missing name")
 	}
 
 	return ns, name, version, nil
+}
+
+// rightmostSplit splits the input path on a given delimiter such that the lhs returns the string to
+// the left of the right-most delimiter and rhs return the string to the right of the right-most
+// delimiter. For example, given path "github.com/package-url/packageurl-go" and delimiter "/" the
+// lhs will be "github.com/package-url" and rhs will be "packageurl-go".
+func rightmostSplit(path string, delim string) (lhs, rhs string) {
+	lastSepIdx := strings.LastIndex(path, delim)
+	rhs = path[lastSepIdx+1:]
+	if lastSepIdx >= 0 {
+		lhs = path[:lastSepIdx]
+	}
+	return lhs, rhs
 }
 
 func parseQualifiers(rawQuery string) (Qualifiers, error) {
@@ -558,25 +605,21 @@ func parseQualifiers(rawQuery string) (Qualifiers, error) {
 		if key == "" {
 			continue
 		}
+		// The key is the lowercase left side.
 		key, value, _ := strings.Cut(key, "=")
-		key, err := url.QueryUnescape(key)
-		if err != nil {
-			return nil, fmt.Errorf("error unescaping qualifier key %q", key)
-		}
+		key = strings.ToLower(key)
 
 		if !validQualifierKey(key) {
 			return nil, fmt.Errorf("invalid qualifier key: '%s'", key)
 		}
 
-		value, err = url.QueryUnescape(value)
+		// The value is the percent-decoded right side.
+		value, err := percentDecode(value)
 		if err != nil {
 			return nil, fmt.Errorf("error unescaping qualifier value %q", value)
 		}
 
-		q = append(q, Qualifier{
-			Key:   strings.ToLower(key),
-			Value: value,
-		})
+		q = append(q, Qualifier{Key: key, Value: value})
 	}
 	return q, nil
 }

--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -625,3 +625,124 @@ func TestNormalize(t *testing.T) {
 		})
 	}
 }
+
+// purlExpectation represents an expected canonical purl and destructured [packageurl.PackageURL]
+// for a given input string.
+type purlExpectation struct {
+	// input represents a user-supplied purl input string to be parsed.
+	input string
+
+	// canonical is the expected canonical string represenation for input.
+	canonical string
+	// purl is the expected [packageurl.PackageURL] for input.
+	purl packageurl.PackageURL
+}
+
+// TestRoundtrip is intended to cover some tricky purl parsing/canonicalization that is not covered
+// by the purl-spec tests (yet).
+func TestRoundtrip(t *testing.T) {
+	tests := []struct {
+		name        string
+		expectation purlExpectation
+	}{
+		{
+			name: "input version with unescaped slashes",
+			expectation: purlExpectation{
+				input:     "pkg:github/golang/mod@refs/tags/v0.30.0",
+				canonical: "pkg:github/golang/mod@refs%2Ftags%2Fv0.30.0",
+				purl: packageurl.PackageURL{
+					Type:       packageurl.TypeGithub,
+					Namespace:  "golang",
+					Name:       "mod",
+					Version:    "refs/tags/v0.30.0",
+					Qualifiers: packageurl.Qualifiers{}}},
+		},
+
+		{
+			name: "go modules can have vanity urls without namespace",
+			expectation: purlExpectation{
+				input:     "pkg:golang/go.opencensus.io@v0.20.1",
+				canonical: "pkg:golang/go.opencensus.io@v0.20.1",
+				purl: packageurl.PackageURL{
+					Type:       packageurl.TypeGolang,
+					Name:       "go.opencensus.io",
+					Version:    "v0.20.1",
+					Qualifiers: packageurl.Qualifiers{}}},
+		},
+
+		{
+			name: "version with unescaped plus characters, qualifiers and subpath",
+			expectation: purlExpectation{
+				input:     "pkg:deb/debian/nuget@2.8.7+md510+dhx1-1.1?distro=stretch&repository_url=http://deb.debian.org&arch=amd64#subpath/to/file",
+				canonical: "pkg:deb/debian/nuget@2.8.7%2Bmd510%2Bdhx1-1.1?arch=amd64&distro=stretch&repository_url=http:%2F%2Fdeb.debian.org#subpath/to/file",
+				purl: packageurl.PackageURL{
+					Type:      packageurl.TypeDebian,
+					Namespace: "debian",
+					Name:      "nuget",
+					Version:   "2.8.7+md510+dhx1-1.1",
+					Qualifiers: packageurl.Qualifiers{
+						{Key: "arch", Value: "amd64"},
+						{Key: "distro", Value: "stretch"},
+						{Key: "repository_url", Value: "http://deb.debian.org"},
+					},
+					Subpath: "subpath/to/file"}},
+		},
+
+		{
+			name: "npm package with unescaped @ in scope and no version",
+			expectation: purlExpectation{
+				input:     "pkg:npm/@opentelemetry/sdk-trace-node",
+				canonical: "pkg:npm/%40opentelemetry/sdk-trace-node",
+				purl: packageurl.PackageURL{
+					Type:       packageurl.TypeNPM,
+					Namespace:  "@opentelemetry",
+					Name:       "sdk-trace-node",
+					Qualifiers: packageurl.Qualifiers{}}},
+		},
+
+		{
+			name: "npm package with unescaped @ in scope and version",
+			expectation: purlExpectation{
+				input:     "pkg:npm/@opentelemetry/sdk-trace-node@2.2.0",
+				canonical: "pkg:npm/%40opentelemetry/sdk-trace-node@2.2.0",
+				purl: packageurl.PackageURL{
+					Type:       packageurl.TypeNPM,
+					Namespace:  "@opentelemetry",
+					Name:       "sdk-trace-node",
+					Version:    "2.2.0",
+					Qualifiers: packageurl.Qualifiers{}}},
+		},
+
+		// See https://github.com/package-url/purl-spec/discussions/814#discussioncomment-15837007
+		{
+			name: "interpret + character in qualifier as literal plus (not space)",
+			expectation: purlExpectation{
+				input:     "pkg:generic/grafana@12.0.1?checksum=sha256:18a348109d3f92772bee72a55eabb9d318596add6a70b92adb6ff8e789d587a8&download_url=https://dl.grafana.com/enterprise/release/grafana-enterprise-12.0.1+security-01.linux-amd64.tar.gz",
+				canonical: "pkg:generic/grafana@12.0.1?checksum=sha256:18a348109d3f92772bee72a55eabb9d318596add6a70b92adb6ff8e789d587a8&download_url=https:%2F%2Fdl.grafana.com%2Fenterprise%2Frelease%2Fgrafana-enterprise-12.0.1%2Bsecurity-01.linux-amd64.tar.gz",
+				purl: packageurl.PackageURL{
+					Type:    packageurl.TypeGeneric,
+					Name:    "grafana",
+					Version: "12.0.1",
+					Qualifiers: packageurl.Qualifiers{
+						{Key: "checksum", Value: "sha256:18a348109d3f92772bee72a55eabb9d318596add6a70b92adb6ff8e789d587a8"},
+						{Key: "download_url", Value: "https://dl.grafana.com/enterprise/release/grafana-enterprise-12.0.1+security-01.linux-amd64.tar.gz"},
+					}}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := packageurl.FromString(tc.expectation.input)
+			if err != nil {
+				t.Fatalf("FromString(%s) unexpectedly failed: %v", tc.expectation.input, err)
+			}
+			if !reflect.DeepEqual(tc.expectation.purl, got) {
+				t.Fatalf("FromString(%s):\nwanted: %#v\ngot: %#v", tc.expectation.input, tc.expectation.purl, got)
+			}
+
+			if got.String() != tc.expectation.canonical {
+				t.Fatalf("String(%s):\nwanted: %s\ngot: %s", tc.expectation.input, tc.expectation.canonical, got.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR makes the library handle some non-canonical input purls a bit more gracefully:

* Versions that include unescaped slashes such as `pkg:github/golang/mod@refs/tags/v0.30.0`  is now correctly parsed as `pkg:github/golang/mod@refs%2Ftags%2Fv0.30.0`.
  * It used to get parsed into `pkg:github/golang/mod%40refs/tags/v0.30.0` which makes very little sense. This turned out to be due to not following the [purl parse procedure](https://github.com/package-url/purl-spec/blob/main/docs/how-to-parse.md) very well so I updated the parsing code to more closely follow that. In particular the parsing of namespace, name and version. 
* Interpret plus characters in input qualifiers literally (instead of parsing them as spaces). This makes a purl like `pkg:generic/grafana@12.0.1?checksum=sha256:18a348109d3f92772bee72a55eabb9d318596add6a70b92adb6ff8e789d587a8&download_url=https://dl.grafana.com/enterprise/release/grafana-enterprise-12.0.1+security-01.linux-amd64.tar.gz` parse correctly. A space (which should be rare) can (and should) still be escaped with `%20` in the input (rather than `+`).
  * This following a [discussion on purl-spec](https://github.com/package-url/purl-spec/discussions/814#discussioncomment-15837007).

Test-cases have been added for these cases, which go a bit outside the purl-spec testsuite.