### PR TITLE
Percent-decode subpath when parsing

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -503,7 +503,13 @@ func FromString(purl string) (PackageURL, error) {
 	// Extract fragment (subpath)
 	var subpath string
 	if idx := strings.IndexByte(remainder, '#'); idx != -1 {
-		subpath = remainder[idx+1:]
+		// A subpath is a percent-encoded string and must be decoded like the
+		// other components (namespace, name, version).
+		decoded, err := percentDecodeSubpath(remainder[idx+1:])
+		if err != nil {
+			return PackageURL{}, fmt.Errorf("error unescaping subpath: %w", err)
+		}
+		subpath = decoded
 		remainder = remainder[:idx]
 	}
 
@@ -584,6 +590,24 @@ func percentDecode(s string) (string, error) {
 	// Note: uses [url.PathUnescape] instead of [url.QueryUnescape] to treat '+' characters
 	// literally (not as space).
 	return url.PathUnescape(s)
+}
+
+// percentDecodeSubpath percent-decodes a subpath by decoding each '/'-separated
+// segment on its own, so an encoded slash inside a segment is not treated as a
+// segment separator. This mirrors the per-segment decoding done for the namespace.
+func percentDecodeSubpath(s string) (string, error) {
+	if !strings.Contains(s, "%") {
+		return s, nil
+	}
+	segments := strings.Split(s, "/")
+	for i, segment := range segments {
+		decoded, err := percentDecode(segment)
+		if err != nil {
+			return "", err
+		}
+		segments[i] = decoded
+	}
+	return strings.Join(segments, "/"), nil
 }
 
 // writePercentEncodedString percent-encodes s as a purl path segment and writes it to the builder.

--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -713,6 +713,19 @@ func TestRoundtrip(t *testing.T) {
 					Qualifiers: packageurl.Qualifiers{}}},
 		},
 
+		{
+			name: "percent-encoded subpath is decoded on parse",
+			expectation: purlExpectation{
+				input:     "pkg:cocoapods/GoogleUtilities@7.5.2#NSData%2Bzlib",
+				canonical: "pkg:cocoapods/GoogleUtilities@7.5.2#NSData%2Bzlib",
+				purl: packageurl.PackageURL{
+					Type:       packageurl.TypeCocoapods,
+					Name:       "GoogleUtilities",
+					Version:    "7.5.2",
+					Qualifiers: packageurl.Qualifiers{},
+					Subpath:    "NSData+zlib"}},
+		},
+
 		// See https://github.com/package-url/purl-spec/discussions/814#discussioncomment-15837007
 		{
 			name: "interpret + character in qualifier as literal plus (not space)",

--- a/packageurl_test.go
+++ b/packageurl_test.go
@@ -396,6 +396,19 @@ func TestQualifierMissingEqual(t *testing.T) {
 	}
 }
 
+// The plain "foo/../bar" form has always been rejected by Normalize. The percent-encoded form
+// used to get through, because Subpath still held %2E%2E when that check ran.
+func TestEncodedDotDotSubpathIsRejected(t *testing.T) {
+	for _, input := range []string{
+		"pkg:generic/name@1.0#foo/../bar",
+		"pkg:generic/name@1.0#foo/%2E%2E/bar",
+	} {
+		if _, err := packageurl.FromString(input); err == nil {
+			t.Errorf("FromString(%s): expected an error, got none", input)
+		}
+	}
+}
+
 func TestNormalize(t *testing.T) {
 	testCases := []struct {
 		name    string


### PR DESCRIPTION
FromString decodes the namespace, name and version components but leaves the subpath percent-encoded. ToString percent-encodes the subpath on output, so a canonical purl whose subpath contains an encoded character does not survive a parse -> String round-trip.

The cocoapods `NSData+zlib` subpath (from the purl-spec test suite) canonicalizes to `pkg:cocoapods/GoogleUtilities@7.5.2#NSData%2Bzlib`. Parsing that string today gives `Subpath = "NSData%2Bzlib"` and re-serializing double-encodes it:

    p, _ := FromString("pkg:cocoapods/GoogleUtilities@7.5.2#NSData%2Bzlib")
    p.Subpath    // "NSData%2Bzlib"  (want "NSData+zlib")
    p.ToString() // pkg:cocoapods/GoogleUtilities@7.5.2#NSData%252Bzlib

Name, version and namespace already decode and round-trip correctly; only the subpath is left raw. This decodes the subpath per '/'-separated segment on parse, matching the namespace handling and the "percent-decode each segment" step in the spec parse procedure. The './' and '../' prefix handling from #68 is unchanged. Added a round-trip test; existing tests and the purl-spec fixtures pass.
