### PR TITLE
Don't sort the caller's Qualifiers in place in String()

### DIFF
--- a/packageurl.go
+++ b/packageurl.go
@@ -291,11 +291,14 @@ func (q Qualifiers) String() string {
 	if len(q) == 0 {
 		return ""
 	}
-	slices.SortFunc(q, func(a, b Qualifier) int { return strings.Compare(a.Key, b.Key) })
+	// Sort a copy: q shares its backing array with the caller's slice, so
+	// sorting in place would reorder their data as a side effect of String().
+	sorted := slices.Clone(q)
+	slices.SortFunc(sorted, func(a, b Qualifier) int { return strings.Compare(a.Key, b.Key) })
 	var b strings.Builder
 	// Estimate capacity: each qualifier needs key + "=" + value + "&"
-	b.Grow(len(q) * 32)
-	for i, qq := range q {
+	b.Grow(len(sorted) * 32)
+	for i, qq := range sorted {
 		if i > 0 {
 			b.WriteByte('&')
 		}

--- a/qualifier_test.go
+++ b/qualifier_test.go
@@ -2,6 +2,7 @@ package packageurl
 
 import (
 	"strings"
+	"sync"
 	"testing"
 )
 
@@ -163,4 +164,70 @@ func TestPercentEncode(t *testing.T) {
 			}
 		})
 	}
+}
+
+// Qualifiers.String and PackageURL.String should not reorder the caller's slice.
+func TestQualifiersStringDoesNotMutateReceiver(t *testing.T) {
+	q := Qualifiers{
+		{Key: "zeta", Value: "1"},
+		{Key: "alpha", Value: "2"},
+		{Key: "mid", Value: "3"},
+	}
+	before := make([]string, len(q))
+	for i, qq := range q {
+		before[i] = qq.Key
+	}
+
+	p := PackageURL{
+		Type:       "generic",
+		Name:       "openssl",
+		Version:    "1.2.3",
+		Qualifiers: q,
+	}
+	got := p.String()
+
+	if want := "pkg:generic/openssl@1.2.3?alpha=2&mid=3&zeta=1"; got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+
+	for i, qq := range q {
+		if qq.Key != before[i] {
+			t.Fatalf("String() reordered the caller's Qualifiers: got %v, want %v", keysOf(q), before)
+		}
+	}
+}
+
+func keysOf(q Qualifiers) []string {
+	out := make([]string, len(q))
+	for i, qq := range q {
+		out[i] = qq.Key
+	}
+	return out
+}
+
+// Two goroutines rendering the same PackageURL shouldn't write to the same
+// backing array. Only fails under -race.
+func TestQualifiersStringConcurrent(t *testing.T) {
+	p := PackageURL{
+		Type:    "generic",
+		Name:    "openssl",
+		Version: "1.2.3",
+		Qualifiers: Qualifiers{
+			{Key: "zeta", Value: "1"},
+			{Key: "alpha", Value: "2"},
+			{Key: "mid", Value: "3"},
+		},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				_ = p.String()
+			}
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
I was reading through the qualifier handling and noticed `Qualifiers.String()` sorts the receiver in place:

```go
slices.SortFunc(q, func(a, b Qualifier) int { return strings.Compare(a.Key, b.Key) })
```

`q` is a slice header copy, but it still points at the caller's backing array. So sorting reorders the caller's own `Qualifiers` as a side effect of asking for a string. Anything holding a parsed `PackageURL` sees its qualifier order silently change the first time it renders it, which is a bit surprising for a method documented as returning "a canonical string representation". `PackageURL.ToString()` hits this on every call, so `PackageURL.String()` has the same effect.

The other half of it is concurrency. Two goroutines rendering the same `PackageURL` both sort that shared array, so they're racing on it. Easy to trigger with `-race`:

```
WARNING: DATA RACE
Read at 0x00c00007a260 by goroutine 9:
  slices.SortFunc[...]()
  github.com/package-url/packageurl-go.Qualifiers.String()
      packageurl.go:294
  github.com/package-url/packageurl-go.(*PackageURL).ToString()
      packageurl.go:473
```

I should be upfront that I found this by reading the code, not from a bug report, and I'm not pointing at a specific downstream project that's been bitten by it. It seemed worth fixing anyway since `String()` on a value type mutating shared state is the kind of thing that shows up as a confusing bug somewhere else entirely.

The fix is to sort a clone. Output is identical (still canonical key order), the extra allocation only happens when there are qualifiers to sort, and the existing `Grow` estimate carries over.

Two tests added: one checks the caller's slice keeps its order across `PackageURL.String()`, and one runs 8 goroutines calling `String()` on a shared purl (that one only fails under `-race`). Both fail on master and pass with the change. Full suite is green with the submodule checked out, including `go test -race ./...`.

Happy to drop the concurrency test if you'd rather not have a race-only test in the suite, since CI doesn't currently run with `-race`.
